### PR TITLE
Add edit mode with notes on sidebar

### DIFF
--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -3,11 +3,13 @@
 let fileList = [];
 let currentIndex = -1;
 let fileIcons = {}; // { index: { trash: bool, star: bool, question: bool } }
+let fileNotes = {}; // { index: string }
 
 export function setFileList(list, index = 0) {
   fileList = list;
   currentIndex = index;
   fileIcons = {};
+  fileNotes = {};
 }
 
 export function addFilesToList(list, index = 0) {
@@ -55,4 +57,13 @@ export function clearFileList() {
   fileList = [];
   currentIndex = -1;
   fileIcons = {};
+  fileNotes = {};
+}
+
+export function setFileNote(index, note) {
+  fileNotes[index] = note;
+}
+
+export function getFileNote(index) {
+  return fileNotes[index] || '';
 }

--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -1,6 +1,6 @@
 // modules/sidebar.js
 
-import { getFileList, getCurrentIndex, getFileIconState } from './fileState.js';
+import { getFileList, getCurrentIndex, getFileIconState, getFileNote, setFileNote } from './fileState.js';
 
 export function initSidebar({ onFileSelected } = {}) {
   const sidebar = document.getElementById('sidebar');
@@ -8,13 +8,22 @@ export function initSidebar({ onFileSelected } = {}) {
   const sidebarIcon = document.getElementById('sidebarIcon');
   const fileListUl = document.getElementById('fileList');
   const searchInput = document.getElementById('searchInput');
+  const editBtn = document.getElementById('toggleEditBtn');
   const filePathSpan = document.getElementById('currentFilePath');
   const fileCount = document.getElementById('fileCount');
+
+  let isEditMode = false;
 
   toggleBtn.addEventListener('click', () => {
     sidebar.classList.toggle('collapsed');
     const isCollapsed = sidebar.classList.contains('collapsed');
     toggleBtn.title = isCollapsed ? 'Open File List' : 'Collapse File List';
+  });
+
+  editBtn.addEventListener('click', () => {
+    isEditMode = !isEditMode;
+    sidebar.classList.toggle('edit-mode', isEditMode);
+    renderFileList(searchInput.value.trim().toLowerCase());
   });
 
   searchInput.addEventListener('input', () => {
@@ -63,10 +72,16 @@ export function initSidebar({ onFileSelected } = {}) {
       
       li.appendChild(left);
 
+      const rightContainer = document.createElement('span');
+      rightContainer.style.display = 'flex';
+      rightContainer.style.alignItems = 'center';
+      rightContainer.style.flexShrink = '0';
+      rightContainer.style.whiteSpace = 'nowrap';
+
       const flags = document.createElement('span');
       flags.style.display = 'flex';
       flags.style.flexShrink = '0';
-      flags.style.whiteSpace = 'nowrap';    
+      flags.style.whiteSpace = 'nowrap';
       const state = getFileIconState(index);
       if (state.trash) {
         const d = document.createElement('i');
@@ -89,7 +104,20 @@ export function initSidebar({ onFileSelected } = {}) {
         q.style.marginLeft = '4px';
         flags.appendChild(q);
       }
-      li.appendChild(flags);
+
+      rightContainer.appendChild(flags);
+
+      const noteInput = document.createElement('input');
+      noteInput.type = 'text';
+      noteInput.className = 'file-note-input';
+      noteInput.value = getFileNote(index);
+      noteInput.addEventListener('click', (e) => e.stopPropagation());
+      noteInput.addEventListener('input', (e) => {
+        setFileNote(index, e.target.value);
+      });
+      rightContainer.appendChild(noteInput);
+
+      li.appendChild(rightContainer);
   
       li.addEventListener('click', () => {
         if (typeof onFileSelected === 'function') {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -21,7 +21,12 @@
          <i id="clearAllBtn" class="fa-solid fa-trash" title="Clear all" style="cursor:pointer;"></i>
        </span>
     </div>
-      <input type="text" id="searchInput" placeholder="Search files..." style="width:100%; margin-bottom: 8px;">
+      <div id="searchContainer" style="display:flex; align-items:center; gap:4px; margin-bottom:8px;">
+        <input type="text" id="searchInput" placeholder="Search files..." style="flex:1;">
+        <button id="toggleEditBtn" class="sidebar-button" title="Edit mode">
+          <i class="fa-solid fa-pen-to-square"></i>
+        </button>
+      </div>
       <ul id="fileList"></ul>
       <div id="Metadata">
         <div style="display:flex;justify-content:space-between;align-items:center; padding-bottom:4px;">

--- a/style.css
+++ b/style.css
@@ -351,6 +351,12 @@ input[type="file"]:hover {
 #searchInput {
   width: 100%;
   box-sizing: border-box;
+}
+
+#searchContainer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
   margin-bottom: 8px;
 }
 
@@ -363,6 +369,10 @@ input[type="file"]:hover {
   box-sizing: border-box;
   transition: width 0.3s ease, opacity 0.3s ease;
   overflow: hidden;
+}
+
+#sidebar.edit-mode {
+  width: 300px;
 }
 
 #sidebar.collapsed {
@@ -476,6 +486,29 @@ input[type="file"]:hover {
 .sidebar-button i {
   color: white;  /* icon 白色 */
   font-size: 15px;
+}
+
+.file-note-input {
+  width: 0;
+  margin-left: 0;
+  padding: 2px 4px;
+  font-size: 13px;
+  height: 20px;
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transition: width 0.3s ease, margin-left 0.3s ease, opacity 0.3s ease;
+}
+
+#sidebar.edit-mode .file-note-input {
+  width: 45px;
+  margin-left: 4px;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* File Path Display 樣式 */


### PR DESCRIPTION
## Summary
- add support for per-file notes in `fileState.js`
- create edit button and search bar container in `sonoradar.html`
- adjust sidebar styling and animations for edit mode
- implement edit mode logic in `sidebar.js`

## Testing
- `node -e "require('./modules/sidebar.js')"`
- `node -e "import('./modules/sidebar.js').then(()=>{}).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_6848c5986250832abef41b56c04a5a6e