### PR TITLE
Remove demo file after first load

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -1,7 +1,7 @@
 // modules/dragDropLoader.js
 
 import { extractGuanoMetadata } from './guanoReader.js';
-import { addFilesToList } from './fileState.js';
+import { addFilesToList, removeFilesByName } from './fileState.js';
 
 export function initDragDropLoader({
   targetElementId,
@@ -79,6 +79,7 @@ export function initDragDropLoader({
     }
 
     const sortedList = validFiles.sort((a, b) => a.name.localeCompare(b.name));
+    removeFilesByName('demo_recording.wav');
     addFilesToList(sortedList, 0);
     await loadFile(sortedList[0]);
   }

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -1,7 +1,7 @@
 // modules/fileLoader.js
 
 import { extractGuanoMetadata } from './guanoReader.js';
-import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex } from './fileState.js';
+import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName } from './fileState.js';
 
 let lastObjectUrl = null;
 
@@ -76,6 +76,7 @@ export function initFileLoader({
     const sortedList = sameDirFiles.sort((a, b) => a.name.localeCompare(b.name));
     const index = sortedList.findIndex(f => f.name === selectedFile.name);
 
+    removeFilesByName('demo_recording.wav');
     addFilesToList(sortedList, index);
     await loadFile(selectedFile);
   });

--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -67,3 +67,16 @@ export function setFileNote(index, note) {
 export function getFileNote(index) {
   return fileNotes[index] || '';
 }
+
+// Remove files that match the given name from the current list. This also resets
+// any stored icon or note state. The currentIndex will be set to -1 so that the
+// caller can decide which file to load next.
+export function removeFilesByName(name) {
+  const filtered = fileList.filter(f => f.name !== name);
+  if (filtered.length !== fileList.length) {
+    fileList = filtered;
+    currentIndex = -1;
+    fileIcons = {};
+    fileNotes = {};
+  }
+}


### PR DESCRIPTION
## Summary
- remove sample recording from list once a user loads their first file
- keep file state clean when removing demo recording

## Testing
- `node -e "require('./modules/fileLoader.js')"`
- `node -e "require('./modules/dragDropLoader.js')"`


------
https://chatgpt.com/codex/tasks/task_e_684940e1ebb8832a9829e29aa1db0e8a