### PR TITLE
Add export module

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -1,7 +1,7 @@
 // modules/dragDropLoader.js
 
 import { extractGuanoMetadata } from './guanoReader.js';
-import { addFilesToList, removeFilesByName } from './fileState.js';
+import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex } from './fileState.js';
 
 export function initDragDropLoader({
   targetElementId,
@@ -45,7 +45,8 @@ export function initDragDropLoader({
     
     try {
       const result = await extractGuanoMetadata(file);
-      guanoOutput.textContent = result || '(No GUANO metadata found)';
+      guanoOutput.textContent = result.raw || '(No GUANO metadata found)';
+      setFileMetadata(getCurrentIndex(), result.parsed);
     } catch (err) {
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }

--- a/modules/exportCsv.js
+++ b/modules/exportCsv.js
@@ -1,0 +1,53 @@
+// modules/exportCsv.js
+
+import { getFileList, getFileMetadata, getFileIconState, getFileNote } from './fileState.js';
+
+export function exportFileListCsv(filename = 'export.csv') {
+  const header = [
+    'File name',
+    'Date',
+    'Time',
+    'Latitude',
+    'Longitude',
+    'Noise',
+    'Star',
+    'Question',
+    'Remark'
+  ];
+  const rows = [header];
+  const files = getFileList();
+  files.forEach((file, idx) => {
+    const meta = getFileMetadata(idx);
+    const icon = getFileIconState(idx);
+    const note = getFileNote(idx);
+    let date = '';
+    let time = '';
+    if (meta.timestamp) {
+      const [d, t] = meta.timestamp.split('T');
+      if (d) date = d.replace(/-/g, '/');
+      if (t) time = t.substring(0, 5).replace(':', '');
+    }
+    rows.push([
+      file.name,
+      date,
+      time,
+      meta.lat || '',
+      meta.lon || '',
+      icon.trash ? 1 : '',
+      icon.star ? 1 : '',
+      icon.question ? 1 : '',
+      note || ''
+    ]);
+  });
+
+  const csv = rows
+    .map((r) => r.map((v) => `"${String(v).replace(/"/g, '""')}"`).join(','))
+    .join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -1,7 +1,7 @@
 // modules/fileLoader.js
 
 import { extractGuanoMetadata } from './guanoReader.js';
-import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName } from './fileState.js';
+import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
 
 let lastObjectUrl = null;
 
@@ -39,7 +39,8 @@ export function initFileLoader({
 
     try {
       const result = await extractGuanoMetadata(file);
-      guanoOutput.textContent = result || '(No GUANO metadata found)';
+      guanoOutput.textContent = result.raw || '(No GUANO metadata found)';
+      setFileMetadata(getCurrentIndex(), result.parsed);
     } catch (err) {
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }

--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -4,12 +4,14 @@ let fileList = [];
 let currentIndex = -1;
 let fileIcons = {}; // { index: { trash: bool, star: bool, question: bool } }
 let fileNotes = {}; // { index: string }
+let fileMetadata = {}; // { index: { timestamp: string, lat: string, lon: string } }
 
 export function setFileList(list, index = 0) {
   fileList = list;
   currentIndex = index;
   fileIcons = {};
   fileNotes = {};
+  fileMetadata = {};
 }
 
 export function addFilesToList(list, index = 0) {
@@ -21,6 +23,14 @@ export function addFilesToList(list, index = 0) {
 
 export function getFileList() {
   return fileList;
+}
+
+export function setFileMetadata(index, metadata) {
+  fileMetadata[index] = metadata;
+}
+
+export function getFileMetadata(index) {
+  return fileMetadata[index] || {};
 }
 
 export function getCurrentIndex() {
@@ -58,6 +68,7 @@ export function clearFileList() {
   currentIndex = -1;
   fileIcons = {};
   fileNotes = {};
+  fileMetadata = {};
 }
 
 export function setFileNote(index, note) {
@@ -78,5 +89,6 @@ export function removeFilesByName(name) {
     currentIndex = -1;
     fileIcons = {};
     fileNotes = {};
+    fileMetadata = {};
   }
 }

--- a/modules/guanoReader.js
+++ b/modules/guanoReader.js
@@ -1,7 +1,7 @@
 // modules/guanoReader.js
 
 export async function extractGuanoMetadata(file) {
-  if (!file) return '(no file selected)';
+  if (!file) return { raw: '(no file selected)', parsed: {} };
   
   const buffer = await file.arrayBuffer();
   const view = new DataView(buffer);
@@ -30,5 +30,25 @@ export async function extractGuanoMetadata(file) {
     if (chunkSize % 2 === 1) pos += 1; // word alignment
   }
 
-  return foundGuano || '(No GUANO metadata found in file)';
+  const rawText = foundGuano || '(No GUANO metadata found in file)';
+  const parsed = {};
+
+  if (foundGuano) {
+    const lines = foundGuano.split(/\r?\n/);
+    for (const line of lines) {
+      const idx = line.indexOf(':');
+      if (idx === -1) continue;
+      const key = line.slice(0, idx).trim();
+      const val = line.slice(idx + 1).trim();
+      if (key === 'Timestamp') {
+        parsed.timestamp = val;
+      } else if (key === 'Loc Position') {
+        const [lat, lon] = val.split(/\s+/);
+        parsed.lat = lat;
+        parsed.lon = lon;
+      }
+    }
+  }
+
+  return { raw: rawText, parsed };
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -54,6 +54,7 @@
         </span>
         <button id="prevBtn" title="Previous file (^)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (v)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
+        <button id="exportBtn" title="Export CSV" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
         <button id="setting" title="Spectrogram setting" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
       </div>
       <!-- Tool Bar -->    
@@ -166,9 +167,9 @@
     import { drawTimeAxis, drawFrequencyGrid } from './modules/axisRenderer.js';
     import { initScrollSync } from './modules/scrollSync.js';
     import { extractGuanoMetadata } from './modules/guanoReader.js';
-    import { initDragDropLoader } from './modules/dragDropLoader.js';
+    import { exportFileListCsv } from './modules/exportCsv.js';
     import { initSidebar } from './modules/sidebar.js';
-    import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList } from './modules/fileState.js';
+    import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, getFileMetadata } from './modules/fileState.js';
 
     const spectrogramHeight = 800;
     let sidebarControl;
@@ -528,7 +529,7 @@
     const clearAllBtn = document.getElementById('clearAllBtn');
     clearAllBtn.addEventListener('click', () => {
       clearFileList();
-      sidebarControl.refresh('');    
+      sidebarControl.refresh('');
       replacePlugin(
         getCurrentColorMap(),
         spectrogramHeight,
@@ -541,6 +542,11 @@
       hoverLineVElem.style.display = 'none';
       zoomControlsElem.style.display = 'none';
       guanoOutput.textContent = '(no file selected)';
+    });
+
+    const exportBtn = document.getElementById('exportBtn');
+    exportBtn.addEventListener('click', () => {
+      exportFileListCsv();
     });
 
     const settingBtn = document.getElementById('setting');


### PR DESCRIPTION
## Summary
- extract CSV export into `exportCsv.js`
- wire up export button to the new module

## Testing
- `node -e "require('./modules/fileState.js');"`
- `node -e "require('./modules/guanoReader.js');"`
- `node -e "require('./modules/fileLoader.js');"`
- `node -e "require('./modules/dragDropLoader.js');"`
- `node -e "require('./modules/exportCsv.js');"`


------
https://chatgpt.com/codex/tasks/task_e_684945be8720832a8df66fd1789fb2fb