### PR TITLE
Add CSV export for file metadata

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -1,7 +1,7 @@
 // modules/dragDropLoader.js
 
-import { extractGuanoMetadata } from './guanoReader.js';
-import { addFilesToList, removeFilesByName } from './fileState.js';
+import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
+import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
 
 export function initDragDropLoader({
   targetElementId,
@@ -46,6 +46,9 @@ export function initDragDropLoader({
     try {
       const result = await extractGuanoMetadata(file);
       guanoOutput.textContent = result || '(No GUANO metadata found)';
+      const meta = parseGuanoMetadata(result);
+      const idx = getCurrentIndex();
+      setFileMetadata(idx, meta);
     } catch (err) {
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }
@@ -80,7 +83,17 @@ export function initDragDropLoader({
 
     const sortedList = validFiles.sort((a, b) => a.name.localeCompare(b.name));
     removeFilesByName('demo_recording.wav');
+    const startIdx = getFileList().length;
     addFilesToList(sortedList, 0);
+    for (let i = 0; i < sortedList.length; i++) {
+      try {
+        const txt = await extractGuanoMetadata(sortedList[i]);
+        const meta = parseGuanoMetadata(txt);
+        setFileMetadata(startIdx + i, meta);
+      } catch (err) {
+        setFileMetadata(startIdx + i, { date: '', time: '', latitude: '', longitude: '' });
+      }
+    }
     await loadFile(sortedList[0]);
   }
 

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -1,7 +1,7 @@
 // modules/fileLoader.js
 
-import { extractGuanoMetadata } from './guanoReader.js';
-import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName } from './fileState.js';
+import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
+import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
 
 let lastObjectUrl = null;
 
@@ -40,6 +40,9 @@ export function initFileLoader({
     try {
       const result = await extractGuanoMetadata(file);
       guanoOutput.textContent = result || '(No GUANO metadata found)';
+      const meta = parseGuanoMetadata(result);
+      const idx = getCurrentIndex();
+      setFileMetadata(idx, meta);
     } catch (err) {
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }
@@ -77,7 +80,17 @@ export function initFileLoader({
     const index = sortedList.findIndex(f => f.name === selectedFile.name);
 
     removeFilesByName('demo_recording.wav');
+    const startIdx = getFileList().length;
     addFilesToList(sortedList, index);
+    for (let i = 0; i < sortedList.length; i++) {
+      try {
+        const txt = await extractGuanoMetadata(sortedList[i]);
+        const meta = parseGuanoMetadata(txt);
+        setFileMetadata(startIdx + i, meta);
+      } catch (err) {
+        setFileMetadata(startIdx + i, { date: '', time: '', latitude: '', longitude: '' });
+      }
+    }
     await loadFile(selectedFile);
   });
 

--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -4,12 +4,14 @@ let fileList = [];
 let currentIndex = -1;
 let fileIcons = {}; // { index: { trash: bool, star: bool, question: bool } }
 let fileNotes = {}; // { index: string }
+let fileMetadata = {}; // { index: { date, time, latitude, longitude } }
 
 export function setFileList(list, index = 0) {
   fileList = list;
   currentIndex = index;
   fileIcons = {};
   fileNotes = {};
+  fileMetadata = {};
 }
 
 export function addFilesToList(list, index = 0) {
@@ -58,6 +60,7 @@ export function clearFileList() {
   currentIndex = -1;
   fileIcons = {};
   fileNotes = {};
+  fileMetadata = {};
 }
 
 export function setFileNote(index, note) {
@@ -66,6 +69,14 @@ export function setFileNote(index, note) {
 
 export function getFileNote(index) {
   return fileNotes[index] || '';
+}
+
+export function setFileMetadata(index, data) {
+  fileMetadata[index] = data;
+}
+
+export function getFileMetadata(index) {
+  return fileMetadata[index] || { date: '', time: '', latitude: '', longitude: '' };
 }
 
 // Remove files that match the given name from the current list. This also resets
@@ -78,5 +89,6 @@ export function removeFilesByName(name) {
     currentIndex = -1;
     fileIcons = {};
     fileNotes = {};
+    fileMetadata = {};
   }
 }

--- a/modules/guanoReader.js
+++ b/modules/guanoReader.js
@@ -32,3 +32,37 @@ export async function extractGuanoMetadata(file) {
 
   return foundGuano || '(No GUANO metadata found in file)';
 }
+
+export function parseGuanoMetadata(text) {
+  if (!text || text.startsWith('(No GUANO')) return {};
+  const lines = text.split(/\r?\n/);
+  const meta = {};
+  lines.forEach(line => {
+    const idx = line.indexOf(':');
+    if (idx === -1) return;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    meta[key] = value;
+  });
+
+  const ts = meta['Timestamp'];
+  if (ts) {
+    const [datePart, timePartWithZone] = ts.split(' ');
+    const timePart = (timePartWithZone || '').split('+')[0];
+    meta._Date = datePart ? datePart.replace(/-/g, '/') : '';
+    meta._Time = timePart ? timePart.slice(0,5).replace(':','') : '';
+  }
+
+  if (meta['Loc Position']) {
+    const [lat, lon] = meta['Loc Position'].split(/\s+/);
+    meta._Latitude = lat || '';
+    meta._Longitude = lon || '';
+  }
+
+  return {
+    date: meta._Date || '',
+    time: meta._Time || '',
+    latitude: meta._Latitude || '',
+    longitude: meta._Longitude || ''
+  };
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -54,6 +54,7 @@
         </span>
         <button id="prevBtn" title="Previous file (^)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (v)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
+        <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
         <button id="setting" title="Spectrogram setting" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
       </div>
       <!-- Tool Bar -->    
@@ -165,10 +166,10 @@
     import { initFrequencyHover } from './modules/frequencyHover.js';
     import { drawTimeAxis, drawFrequencyGrid } from './modules/axisRenderer.js';
     import { initScrollSync } from './modules/scrollSync.js';
-    import { extractGuanoMetadata } from './modules/guanoReader.js';
+    import { extractGuanoMetadata, parseGuanoMetadata } from './modules/guanoReader.js';
     import { initDragDropLoader } from './modules/dragDropLoader.js';
     import { initSidebar } from './modules/sidebar.js';
-    import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList } from './modules/fileState.js';
+    import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, getFileMetadata, setFileMetadata } from './modules/fileState.js';
 
     const spectrogramHeight = 800;
     let sidebarControl;
@@ -528,7 +529,7 @@
     const clearAllBtn = document.getElementById('clearAllBtn');
     clearAllBtn.addEventListener('click', () => {
       clearFileList();
-      sidebarControl.refresh('');    
+      sidebarControl.refresh('');
       replacePlugin(
         getCurrentColorMap(),
         spectrogramHeight,
@@ -548,7 +549,55 @@
     
     settingBtn.addEventListener('click', () => {
       toolBar.classList.toggle('open');
-    });    
+    });
+
+    const exportBtn = document.getElementById('exportBtn');
+    exportBtn.addEventListener('click', async () => {
+      const files = getFileList();
+      const headers = ['File name','Remark','Date','Time','Latitude','Longitude','Noise','Star','Question'];
+      const rows = [headers.join(',')];
+
+      for (let i = 0; i < files.length; i++) {
+        const file = files[i];
+        let meta = getFileMetadata(i);
+        if (!meta || (!meta.date && !meta.time && !meta.latitude && !meta.longitude)) {
+          try {
+            const txt = await extractGuanoMetadata(file);
+            meta = parseGuanoMetadata(txt);
+            setFileMetadata(i, meta);
+          } catch (err) {
+            meta = { date: '', time: '', latitude: '', longitude: '' };
+          }
+        }
+
+        const flags = getFileIconState(i);
+        const note = getFileNote(i);
+        const row = [
+          file.name,
+          note,
+          meta.date,
+          meta.time,
+          meta.latitude,
+          meta.longitude,
+          flags.trash ? '1' : '0',
+          flags.star ? '1' : '0',
+          flags.question ? '1' : '0'
+        ].map(v => `"${String(v).replace(/"/g, '""')}"`).join(',');
+        rows.push(row);
+      }
+
+      const csvContent = rows.join('\n');
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'export.csv';
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- store GUANO metadata for loaded files
- parse GUANO metadata
- export file list with notes and flags as CSV
- include export button in UI

## Testing
- `node -v`
- `node -e "console.log('test')"`


------
https://chatgpt.com/codex/tasks/task_e_68494c2453d8832a9abc8ebed717dccc