### PR TITLE
Add loading overlay when loading WAV files

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -126,8 +126,11 @@
             <i class="fas fa-cloud-arrow-up" style="font-size:60px; color:#666; margin-bottom:10px;"></i>
             <div>Drop WAV file(s) or folder here</div>
           </div>
-        </div>      
-        <div id="viewer-container">
+          </div>
+          <div id="loading-overlay" class="loading-overlay">
+            <div class="spinner"></div>
+          </div>
+          <div id="viewer-container">
           <div id="spectrogram-only" style="height: 800px;"></div>
           <canvas id="freq-grid"></canvas>
         </div>
@@ -207,7 +210,8 @@
       sampleRate: currentSampleRate,
     });
     const overlay = document.getElementById('drop-overlay');
-    overlay.style.display = 'flex';    
+    const loadingOverlay = document.getElementById('loading-overlay');
+    overlay.style.display = 'flex';
     updateSpectrogramSettingsText();
 
     fileLoaderControl = initFileLoader({
@@ -221,13 +225,17 @@
         hoverLineElem.style.display = 'block';
         hoverLineVElem.style.display = 'block';
         zoomControlsElem.style.display = 'flex';
-        sidebarControl.refresh(file.name);        
+        sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
+        loadingOverlay.style.display = 'flex';
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
       },
-      onAfterLoad: () => { freqHoverControl?.refreshHover(); }
+      onAfterLoad: () => {
+        loadingOverlay.style.display = 'none';
+        freqHoverControl?.refreshHover();
+      }
     });
     sidebarControl = initSidebar({
       onFileSelected: (index) => {
@@ -396,14 +404,18 @@
         hoverLineElem.style.display = 'block';
         hoverLineVElem.style.display = 'block';
         zoomControlsElem.style.display = 'flex';
-        sidebarControl.refresh(file.name);      
+        sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
+        loadingOverlay.style.display = 'flex';
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
       },
-      onAfterLoad: () => { freqHoverControl?.refreshHover(); }
-    });   
+      onAfterLoad: () => {
+        loadingOverlay.style.display = 'none';
+        freqHoverControl?.refreshHover();
+      }
+    });
 
     initScrollSync({
       scrollSourceId: 'viewer-container',
@@ -538,6 +550,7 @@
         getOverlapPercent()
       );
       overlay.style.display = 'flex';
+      loadingOverlay.style.display = 'none';
       hoverLineElem.style.display = 'none';
       hoverLineVElem.style.display = 'none';
       zoomControlsElem.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -534,3 +534,32 @@ input[type="file"]:hover {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Loading overlay for file operations */
+#loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 20px;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+  pointer-events: none;
+}
+
+#loading-overlay .spinner {
+  border: 4px solid rgba(255, 255, 255, 0.6);
+  border-top: 4px solid #333;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- show a semi-transparent loading overlay while WAV files load
- hide the overlay after file loads
- implement simple spinner animation in CSS

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684967a59370832a8a044d1b9bb60b5b