### PR TITLE
Fix immediate loading overlay display

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -81,6 +81,10 @@ export function initDragDropLoader({
       return;
     }
 
+    if (typeof onBeforeLoad === 'function') {
+      onBeforeLoad();
+    }
+
     const sortedList = validFiles.sort((a, b) => a.name.localeCompare(b.name));
     removeFilesByName('demo_recording.wav');
     const startIdx = getFileList().length;

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -74,6 +74,10 @@ export function initFileLoader({
     const selectedFile = files[0];
     if (!selectedFile) return;
 
+    if (typeof onBeforeLoad === 'function') {
+      onBeforeLoad();
+    }
+
     const sameDirFiles = files.filter(f => f.name.endsWith('.wav'));
 
     const sortedList = sameDirFiles.sort((a, b) => a.name.localeCompare(b.name));


### PR DESCRIPTION
## Summary
- display loading overlay as soon as files start loading

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68496b94e358832aa3a27c86f51ad37e