### PR TITLE
Improve sidebar icon spacing

### DIFF
--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -81,29 +81,24 @@ export function initSidebar({ onFileSelected } = {}) {
       rightContainer.style.whiteSpace = 'nowrap';
 
       const flags = document.createElement('span');
-      flags.style.display = 'flex';
-      flags.style.flexShrink = '0';
-      flags.style.whiteSpace = 'nowrap';
+      flags.className = 'flag-icons';
       const state = getFileIconState(index);
       if (state.trash) {
         const d = document.createElement('i');
         d.className = 'fa-solid fa-trash';
         d.style.color = 'gray';
-        d.style.marginLeft = '4px';
         flags.appendChild(d);
       }
       if (state.star) {
         const s = document.createElement('i');
         s.className = 'fa-solid fa-star';
         s.style.color = '#FFD700';
-        s.style.marginLeft = '4px';
         flags.appendChild(s);
       }
       if (state.question) {
         const q = document.createElement('i');
         q.className = 'fa-solid fa-question';
         q.style.color = 'red';
-        q.style.marginLeft = '4px';
         flags.appendChild(q);
       }
 

--- a/style.css
+++ b/style.css
@@ -488,27 +488,37 @@ input[type="file"]:hover {
   font-size: 15px;
 }
 
+.flag-icons {
+  display: flex;
+  flex-shrink: 0;
+  white-space: nowrap;
+  gap: 4px;
+}
+
 .file-note-input {
   width: 0;
   margin-left: 0;
-  display: none;
-  padding: 2px 4px;
+  display: inline-block;
+  padding: 0;
   font-size: 13px;
   height: 20px;
   background-color: #eee;
   border: 1px solid #ccc;
   border-radius: 4px;
+  border-width: 0;
   box-sizing: border-box;
   overflow: hidden;
   opacity: 0;
   pointer-events: none;
-  transition: width 0.3s ease, margin-left 0.3s ease, opacity 0.3s ease;
+  transition: width 0.3s ease, margin-left 0.3s ease, opacity 0.3s ease,
+              padding 0.3s ease, border-width 0.3s ease;
 }
 
 #sidebar.edit-mode .file-note-input {
   width: 100px;
-  display: block;
   margin-left: 4px;
+  padding: 2px 4px;
+  border-width: 1px;
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary
- add `.flag-icons` style for flex-gap spacing
- remove inline margins from sidebar icons
- fix leftover whitespace when collapsed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68496e896110832a81db71bae408e0c7