### PR TITLE
Add Tag Mode UI

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -36,7 +36,7 @@
         <pre id="guano-output">(no file selected)</pre>
       </div>
   </div>
-  <div style="flex-grow: 1; overflow-x: hidden; padding-left: 15px;">  
+  <div id="main-area" style="flex-grow: 1; overflow-x: hidden; padding-left: 15px; position: relative;">
     
     <div id="control-bar">
       <!-- Top Bar -->
@@ -54,6 +54,7 @@
         </span>
         <button id="prevBtn" title="Previous file (^)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (v)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
+        <button id="tagBtn" title="Tag Mode" class="sidebar-button"><i class="fa-solid fa-tags"></i></button>
         <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
         <button id="setting" title="Spectrogram setting" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
       </div>
@@ -95,8 +96,9 @@
         </label>  
       </div>
     </div>
-<!-------- Spectrogram Start -------->      
-    <div id="whole-spectrogram">    
+<!-------- Spectrogram Start -------->
+    <div id="tag-container"></div>
+    <div id="whole-spectrogram">
       <div id="spectrogram-settings" style="
         padding: 0 0 2px;
         margin-left: 45px;
@@ -188,7 +190,27 @@
     const freqLabelContainer = document.getElementById('freq-labels');
     const hoverLineElem = document.getElementById('hover-line');
     const hoverLineVElem = document.getElementById('hover-line-vertical');
-    const zoomControlsElem = document.getElementById('zoom-controls');    
+    const zoomControlsElem = document.getElementById('zoom-controls');
+    const tagContainer = document.getElementById('tag-container');
+    const mainArea = document.getElementById('main-area');
+    const tagBtn = document.getElementById('tagBtn');
+    const tagInputs = [];
+    const editTagsBtn = document.createElement('button');
+    editTagsBtn.id = 'editTagsBtn';
+    editTagsBtn.textContent = 'Edit Tags';
+    const confirmTagsBtn = document.createElement('button');
+    confirmTagsBtn.id = 'confirmTagsBtn';
+    confirmTagsBtn.textContent = 'Confirm Tags';
+    for (let i = 0; i < 25; i++) {
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'tag-input-button';
+      inp.readOnly = true;
+      tagInputs.push(inp);
+      tagContainer.appendChild(inp);
+    }
+    tagContainer.appendChild(editTagsBtn);
+    tagContainer.appendChild(confirmTagsBtn);
     let duration = 0;
     let currentFreqMin = 0;
     let currentFreqMax = 128;
@@ -557,6 +579,33 @@
       hoverLineVElem.style.display = 'none';
       zoomControlsElem.style.display = 'none';
       guanoOutput.textContent = '(no file selected)';
+    });
+
+    tagBtn.addEventListener('click', () => {
+      mainArea.classList.toggle('tag-mode');
+    });
+
+    editTagsBtn.addEventListener('click', () => {
+      tagInputs.forEach(inp => { inp.readOnly = false; });
+    });
+
+    confirmTagsBtn.addEventListener('click', () => {
+      tagInputs.forEach(inp => { inp.readOnly = true; });
+    });
+
+    tagContainer.addEventListener('click', (e) => {
+      if (e.target.classList.contains('tag-input-button') && e.target.readOnly) {
+        const text = e.target.value.trim();
+        if (!text) return;
+        const idx = getCurrentIndex();
+        if (idx < 0) return;
+        const current = getFileNote(idx);
+        const parts = current ? current.split(',').map(s => s.trim()).filter(s => s) : [];
+        parts.push(text);
+        const newNote = parts.join(', ');
+        setFileNote(idx, newNote);
+        sidebarControl.refresh(getFileList()[idx].name, false);
+      }
     });
 
     const settingBtn = document.getElementById('setting');

--- a/style.css
+++ b/style.css
@@ -569,3 +569,38 @@ input[type="file"]:hover {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+#tag-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100px;
+  display: none;
+}
+
+#tag-container .tag-input-button {
+  width: 90px;
+  margin-bottom: 2px;
+  padding: 2px 4px;
+  font-size: 13px;
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+#tag-container button {
+  width: 100%;
+  margin-top: 4px;
+  padding: 2px 4px;
+  box-sizing: border-box;
+}
+
+#main-area.tag-mode #tag-container {
+  display: block;
+}
+
+#main-area.tag-mode #whole-spectrogram {
+  margin-left: 100px;
+  transition: margin-left 0.3s ease;
+}


### PR DESCRIPTION
## Summary
- add Tag button to the top bar
- shift spectrogram when entering Tag Mode
- show tag inputs when Tag Mode is active
- allow editing tag inputs and applying tags to file notes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68499224cf20832a810f48486651d8d3