### PR TITLE
Add Tag mode panel

### DIFF
--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -65,7 +65,8 @@ export function initFileLoader({
 
     if (typeof onAfterLoad === 'function') {
       onAfterLoad();
-    }    
+    }
+    document.dispatchEvent(new Event('file-loaded'));
     
   }
 

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -54,6 +54,7 @@
         </span>
         <button id="prevBtn" title="Previous file (^)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (v)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
+        <button id="toggleTagModeBtn" title="Tag mode" class="sidebar-button"><i class="fa-solid fa-tags"></i></button>
         <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
         <button id="setting" title="Spectrogram setting" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
       </div>
@@ -95,8 +96,10 @@
         </label>  
       </div>
     </div>
-<!-------- Spectrogram Start -------->      
-    <div id="whole-spectrogram">    
+<!-------- Spectrogram Start -------->
+    <div id="spectrogram-wrapper" style="position: relative;">
+      <div id="tag-panel"></div>
+      <div id="whole-spectrogram">
       <div id="spectrogram-settings" style="
         padding: 0 0 2px;
         margin-left: 45px;
@@ -613,6 +616,114 @@
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     });
+
+    // ===== Tag Mode =====
+    const toggleTagModeBtn = document.getElementById('toggleTagModeBtn');
+    const tagPanel = document.getElementById('tag-panel');
+    const editTagsBtn = document.createElement('button');
+    editTagsBtn.id = 'editTagsBtn';
+    editTagsBtn.textContent = 'Edit Tags';
+    editTagsBtn.className = 'flat-icon-button';
+    const confirmTagsBtn = document.createElement('button');
+    confirmTagsBtn.id = 'confirmTagsBtn';
+    confirmTagsBtn.textContent = 'Confirm Tags';
+    confirmTagsBtn.className = 'flat-icon-button';
+    const tagButtons = [];
+    for (let i = 1; i <= 25; i++) {
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.className = 'tag-button';
+      inp.value = `Bat #${i}`;
+      inp.readOnly = true;
+      inp.addEventListener('click', () => handleTagClick(inp));
+      tagPanel.appendChild(inp);
+      tagButtons.push(inp);
+    }
+    tagPanel.appendChild(editTagsBtn);
+    tagPanel.appendChild(confirmTagsBtn);
+
+    let wasSidebarEdit = false;
+
+    function updateTagButtonStates() {
+      const idx = getCurrentIndex();
+      const note = idx >= 0 ? getFileNote(idx) : '';
+      const tags = note.split(',').map(t => t.trim()).filter(t => t);
+      tagButtons.forEach(btn => {
+        if (tags.includes(btn.value.trim())) {
+          btn.classList.add('active');
+        } else {
+          btn.classList.remove('active');
+        }
+      });
+    }
+
+    function handleTagClick(btn) {
+      if (!btn.readOnly) return;
+      const idx = getCurrentIndex();
+      if (idx < 0) return;
+      const tag = btn.value.trim();
+      let note = getFileNote(idx);
+      const tags = note ? note.split(',').map(t => t.trim()).filter(t => t) : [];
+      const pos = tags.indexOf(tag);
+      if (pos >= 0) {
+        tags.splice(pos, 1);
+        btn.classList.remove('active');
+      } else {
+        tags.push(tag);
+        btn.classList.add('active');
+      }
+      const newNote = tags.join(', ');
+      setFileNote(idx, newNote);
+      const listItems = document.querySelectorAll('#fileList li');
+      if (idx >= 0 && idx < listItems.length) {
+        const input = listItems[idx].querySelector('.file-note-input');
+        if (input) input.value = newNote;
+      }
+    }
+
+    editTagsBtn.addEventListener('click', () => {
+      tagButtons.forEach(btn => {
+        btn.readOnly = false;
+        btn.classList.add('editing');
+      });
+    });
+
+    confirmTagsBtn.addEventListener('click', () => {
+      tagButtons.forEach(btn => {
+        btn.readOnly = true;
+        btn.classList.remove('editing');
+      });
+      updateTagButtonStates();
+    });
+
+    function enterTagMode() {
+      document.body.classList.add('tag-mode-active');
+      toggleTagModeBtn.classList.add('tag-active');
+      wasSidebarEdit = document.getElementById('sidebar').classList.contains('edit-mode');
+      if (!wasSidebarEdit) {
+        document.getElementById('toggleEditBtn').click();
+      }
+      updateTagButtonStates();
+    }
+
+    function exitTagMode() {
+      document.body.classList.remove('tag-mode-active');
+      toggleTagModeBtn.classList.remove('tag-active');
+      if (!wasSidebarEdit && document.getElementById('sidebar').classList.contains('edit-mode')) {
+        document.getElementById('toggleEditBtn').click();
+      }
+    }
+
+    toggleTagModeBtn.addEventListener('click', () => {
+      if (document.body.classList.contains('tag-mode-active')) {
+        exitTagMode();
+      } else {
+        enterTagMode();
+      }
+    });
+
+    // update tags when file changes
+    document.addEventListener('file-loaded', updateTagButtonStates);
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -569,3 +569,63 @@ input[type="file"]:hover {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* === Tag Mode === */
+#tag-panel {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100px;
+  padding-left: 10px;
+  box-sizing: border-box;
+}
+
+body.tag-mode-active #tag-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+#whole-spectrogram {
+  transition: transform 0.3s ease;
+}
+
+body.tag-mode-active #whole-spectrogram {
+  transform: translateX(100px);
+}
+
+body.tag-mode-active #toggleTagModeBtn {
+  background-color: #007bff;
+}
+
+.tag-button {
+  width: 90px;
+  padding-left: 10px;
+  margin-bottom: 4px;
+  background-color: #fafafa;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+  font-size: 13px;
+}
+
+.tag-button.active {
+  background-color: #ffd700;
+}
+
+.tag-button.editing {
+  background-color: #fff;
+}
+
+#editTagsBtn {
+  margin-top: 8px;
+  background-color: #007bff;
+  color: #fff;
+}
+
+#confirmTagsBtn {
+  margin-top: 4px;
+  background-color: #28a745;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add Tag Mode button to top bar
- shift spectrogram and show Tag panel when Tag Mode active
- allow editing and toggling tags
- dispatch `file-loaded` event when files change

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849a38a369c832ab3bd14b965e7d842