### PR TITLE
Update tag panel layout

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -629,16 +629,23 @@
     confirmTagsBtn.textContent = 'Confirm Tags';
     confirmTagsBtn.className = 'flat-icon-button';
     const tagButtons = [];
-    for (let i = 1; i <= 25; i++) {
+    const defaultTags = [
+      'JP', 'LP', 'CP', 'KP', 'LBB', 'GBB', 'CN', 'LYB',
+      'HLB', 'ALB', 'CHB', 'IHB', 'LHB',
+      'GBW', 'LBW', 'ABW',
+      'HM', 'RBFM', 'CM', 'WM',
+      'BTB', 'WFTB'
+    ];
+    defaultTags.forEach(tag => {
       const inp = document.createElement('input');
       inp.type = 'text';
       inp.className = 'tag-button';
-      inp.value = `Bat #${i}`;
+      inp.value = tag;
       inp.readOnly = true;
       inp.addEventListener('click', () => handleTagClick(inp));
       tagPanel.appendChild(inp);
       tagButtons.push(inp);
-    }
+    });
     tagPanel.appendChild(editTagsBtn);
     tagPanel.appendChild(confirmTagsBtn);
 

--- a/style.css
+++ b/style.css
@@ -577,7 +577,6 @@ input[type="file"]:hover {
   top: 0;
   left: 0;
   width: 100px;
-  padding-left: 10px;
   box-sizing: border-box;
 }
 
@@ -603,6 +602,7 @@ body.tag-mode-active #toggleTagModeBtn {
   width: 90px;
   padding-left: 10px;
   margin-bottom: 4px;
+  height: 25px;
   background-color: #fafafa;
   border: 1px solid #ccc;
   border-radius: 4px;


### PR DESCRIPTION
## Summary
- update default tag list and reduce to 22 buttons
- remove extra padding on the tag panel
- set tag button height to 25px

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849af791d1c832ab2f4b1d71fed7ba3