### PR TITLE
Improve overlay behavior and tag button state

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -22,10 +22,12 @@ export function initDragDropLoader({
 
   function showOverlay() {
     overlay.style.display = 'flex';
+    document.dispatchEvent(new Event('drop-overlay-show'));
   }
 
   function hideOverlay() {
     overlay.style.display = 'none';
+    document.dispatchEvent(new Event('drop-overlay-hide'));
   }
 
   async function loadFile(file) {

--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -22,6 +22,7 @@ export function initFrequencyHover({
   const container = document.getElementById('spectrogram-only');
   const persistentLines = [];
   const selections = [];
+  let persistentLinesEnabled = true;
   const scrollbarThickness = 2;
   const edgeThreshold = 5;
   
@@ -158,7 +159,7 @@ export function initFrequencyHover({
   });
 
   viewer.addEventListener('contextmenu', (e) => {
-    if (isOverTooltip) return;
+    if (!persistentLinesEnabled || isOverTooltip) return;
     e.preventDefault();
     const rect = fixedOverlay.getBoundingClientRect();
     const y = e.clientY - rect.top;
@@ -408,7 +409,8 @@ export function initFrequencyHover({
     refreshHover: () => {
       if (lastClientX !== null && lastClientY !== null) {
         updateHoverDisplay({ clientX: lastClientX, clientY: lastClientY });
-      }      
-    }
+      }
+    },
+    setPersistentLinesEnabled: (val) => { persistentLinesEnabled = val; }
   };
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -193,7 +193,8 @@
     const freqLabelContainer = document.getElementById('freq-labels');
     const hoverLineElem = document.getElementById('hover-line');
     const hoverLineVElem = document.getElementById('hover-line-vertical');
-    const zoomControlsElem = document.getElementById('zoom-controls');    
+    const hoverLabelElem = document.getElementById('hover-label');
+    const zoomControlsElem = document.getElementById('zoom-controls');
     let duration = 0;
     let currentFreqMin = 0;
     let currentFreqMax = 128;
@@ -218,7 +219,29 @@
     });
     const overlay = document.getElementById('drop-overlay');
     const loadingOverlay = document.getElementById('loading-overlay');
-    overlay.style.display = 'flex';
+
+    function showDropOverlay() {
+      overlay.style.display = 'flex';
+      overlay.style.pointerEvents = 'auto';
+      hoverLineElem.style.display = 'none';
+      hoverLineVElem.style.display = 'none';
+      hoverLabelElem.style.display = 'none';
+      viewer.classList.remove('hide-cursor');
+      freqHoverControl?.setPersistentLinesEnabled(false);
+    }
+
+    function hideDropOverlay() {
+      overlay.style.display = 'none';
+      overlay.style.pointerEvents = 'none';
+      hoverLineElem.style.display = 'block';
+      hoverLineVElem.style.display = 'block';
+      freqHoverControl?.setPersistentLinesEnabled(true);
+      freqHoverControl?.refreshHover();
+    }
+
+    showDropOverlay();
+    document.addEventListener('drop-overlay-show', showDropOverlay);
+    document.addEventListener('drop-overlay-hide', hideDropOverlay);
     updateSpectrogramSettingsText();
 
     fileLoaderControl = initFileLoader({
@@ -228,9 +251,7 @@
       colorMap: [],
       onPluginReplaced: () => {},
       onFileLoaded: (file) => {
-        overlay.style.display = 'none';
-        hoverLineElem.style.display = 'block';
-        hoverLineVElem.style.display = 'block';
+        hideDropOverlay();
         zoomControlsElem.style.display = 'flex';
         sidebarControl.refresh(file.name);
       },
@@ -247,7 +268,7 @@
     sidebarControl = initSidebar({
       onFileSelected: (index) => {
         fileLoaderControl.loadFileAtIndex(index);
-        overlay.style.display = 'none'; 
+        hideDropOverlay();
       }
     });
  
@@ -407,9 +428,7 @@
       colorMap: [],
       onPluginReplaced: () => {},
       onFileLoaded: (file) => {
-        overlay.style.display = 'none';
-        hoverLineElem.style.display = 'block';
-        hoverLineVElem.style.display = 'block';
+        hideDropOverlay();
         zoomControlsElem.style.display = 'flex';
         sidebarControl.refresh(file.name);
       },
@@ -556,12 +575,11 @@
         currentFreqMax,
         getOverlapPercent()
       );
-      overlay.style.display = 'flex';
+      showDropOverlay();
       loadingOverlay.style.display = 'none';
-      hoverLineElem.style.display = 'none';
-      hoverLineVElem.style.display = 'none';
       zoomControlsElem.style.display = 'none';
       guanoOutput.textContent = '(no file selected)';
+      updateTagButtonStates();
     });
 
     const settingBtn = document.getElementById('setting');


### PR DESCRIPTION
## Summary
- disable persistent line drawing during drag-and-drop overlay
- show/hide overlay through helper functions that also handle cursor and hover display
- restore hoverlines on file load and when overlay disappears
- reset tag button states when the file list is cleared

## Testing
- `node --check modules/frequencyHover.js`
- `node --check modules/dragDropLoader.js`


------
https://chatgpt.com/codex/tasks/task_e_684bf79de20c832a8b825e043cf2ee6f