### PR TITLE
Refactor CSV export to standalone module

### DIFF
--- a/modules/exportCsv.js
+++ b/modules/exportCsv.js
@@ -1,0 +1,65 @@
+// modules/exportCsv.js
+
+import { getFileList, getFileIconState, getFileNote, getFileMetadata, setFileMetadata } from './fileState.js';
+import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
+
+async function generateCsvRows() {
+  const files = getFileList();
+  const headers = ['File name','Remark','Date','Time','Latitude','Longitude','Noise','Star','Question'];
+  const rows = [headers.join(',')];
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    let meta = getFileMetadata(i);
+    if (!meta || (!meta.date && !meta.time && !meta.latitude && !meta.longitude)) {
+      try {
+        const txt = await extractGuanoMetadata(file);
+        meta = parseGuanoMetadata(txt);
+        setFileMetadata(i, meta);
+      } catch (err) {
+        meta = { date: '', time: '', latitude: '', longitude: '' };
+      }
+    }
+
+    const flags = getFileIconState(i);
+    const note = getFileNote(i);
+    const row = [
+      file.name,
+      note,
+      meta.date,
+      meta.time,
+      meta.latitude,
+      meta.longitude,
+      flags.trash ? '1' : '0',
+      flags.star ? '1' : '0',
+      flags.question ? '1' : '0'
+    ].map(v => `"${String(v).replace(/"/g, '""')}"`).join(',');
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+async function exportCsv() {
+  const rows = await generateCsvRows();
+  const csvContent = rows.join('\n');
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'export.csv';
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function initExportCsv({ buttonId = 'exportBtn' } = {}) {
+  const btn = document.getElementById(buttonId);
+  if (!btn) {
+    console.warn(`[exportCsv] Button with id '${buttonId}' not found.`);
+    return;
+  }
+  btn.addEventListener('click', exportCsv);
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -176,7 +176,7 @@
     import { initFrequencyHover } from './modules/frequencyHover.js';
     import { drawTimeAxis, drawFrequencyGrid } from './modules/axisRenderer.js';
     import { initScrollSync } from './modules/scrollSync.js';
-    import { extractGuanoMetadata, parseGuanoMetadata } from './modules/guanoReader.js';
+    import { initExportCsv } from './modules/exportCsv.js';
     import { initDragDropLoader } from './modules/dragDropLoader.js';
     import { initSidebar } from './modules/sidebar.js';
     import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata } from './modules/fileState.js';
@@ -589,53 +589,7 @@
       toolBar.classList.toggle('open');
     });
 
-    const exportBtn = document.getElementById('exportBtn');
-    exportBtn.addEventListener('click', async () => {
-      const files = getFileList();
-      const headers = ['File name','Remark','Date','Time','Latitude','Longitude','Noise','Star','Question'];
-      const rows = [headers.join(',')];
-
-      for (let i = 0; i < files.length; i++) {
-        const file = files[i];
-        let meta = getFileMetadata(i);
-        if (!meta || (!meta.date && !meta.time && !meta.latitude && !meta.longitude)) {
-          try {
-            const txt = await extractGuanoMetadata(file);
-            meta = parseGuanoMetadata(txt);
-            setFileMetadata(i, meta);
-          } catch (err) {
-            meta = { date: '', time: '', latitude: '', longitude: '' };
-          }
-        }
-
-        const flags = getFileIconState(i);
-        const note = getFileNote(i);
-        const row = [
-          file.name,
-          note,
-          meta.date,
-          meta.time,
-          meta.latitude,
-          meta.longitude,
-          flags.trash ? '1' : '0',
-          flags.star ? '1' : '0',
-          flags.question ? '1' : '0'
-        ].map(v => `"${String(v).replace(/"/g, '""')}"`).join(',');
-        rows.push(row);
-      }
-
-      const csvContent = rows.join('\n');
-      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'export.csv';
-      a.style.display = 'none';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    });
+    initExportCsv();
 
     const toggleTagModeBtn = document.getElementById('toggleTagModeBtn');
       const tagPanel = document.getElementById('tag-panel');


### PR DESCRIPTION
## Summary
- extract CSV export logic into `modules/exportCsv.js`
- load the new module in `sonoradar.html`
- initialize export button with `initExportCsv`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c046225d0832aa491059474e03970