### PR TITLE
Refactor tag functions into module

### DIFF
--- a/modules/tagControl.js
+++ b/modules/tagControl.js
@@ -1,0 +1,125 @@
+// modules/tagControl.js
+
+import { getCurrentIndex, getFileNote, setFileNote } from './fileState.js';
+
+export function initTagControl() {
+  const toggleTagModeBtn = document.getElementById('toggleTagModeBtn');
+  const tagPanel = document.getElementById('tag-panel');
+
+  const editTagsBtn = document.createElement('button');
+  editTagsBtn.id = 'editTagsBtn';
+  editTagsBtn.textContent = 'Edit Tags';
+  editTagsBtn.className = 'flat-icon-button';
+
+  const tagButtons = [];
+  const defaultTags = [
+    'JP', 'LP', 'CP', 'KP', 'LBB', 'GBB', 'CN', 'LYB',
+    'HLB', 'ALB', 'CHB', 'IHB', 'LHB',
+    'GBW', 'LBW', 'ABW',
+    'HM', 'RBFM', 'CM', 'WM',
+    'BTB', 'WFTB'
+  ];
+
+  defaultTags.forEach(tag => {
+    const inp = document.createElement('input');
+    inp.type = 'text';
+    inp.className = 'tag-button';
+    inp.value = tag;
+    inp.readOnly = true;
+    inp.addEventListener('click', () => handleTagClick(inp));
+    tagPanel.appendChild(inp);
+    tagButtons.push(inp);
+  });
+  tagPanel.appendChild(editTagsBtn);
+
+  let wasSidebarEdit = false;
+  let tagEditing = false;
+
+  function updateTagButtonStates() {
+    const idx = getCurrentIndex();
+    const note = idx >= 0 ? getFileNote(idx) : '';
+    const tags = note.split(',').map(t => t.trim()).filter(t => t);
+    tagButtons.forEach(btn => {
+      if (tags.includes(btn.value.trim())) {
+        btn.classList.add('active');
+      } else {
+        btn.classList.remove('active');
+      }
+    });
+  }
+
+  function handleTagClick(btn) {
+    if (!btn.readOnly) return;
+    const idx = getCurrentIndex();
+    if (idx < 0) return;
+    const tag = btn.value.trim();
+    let note = getFileNote(idx);
+    const tags = note ? note.split(',').map(t => t.trim()).filter(t => t) : [];
+    const pos = tags.indexOf(tag);
+    if (pos >= 0) {
+      tags.splice(pos, 1);
+      btn.classList.remove('active');
+    } else {
+      tags.push(tag);
+      btn.classList.add('active');
+    }
+    const newNote = tags.join(', ');
+    setFileNote(idx, newNote);
+    const listItems = document.querySelectorAll('#fileList li');
+    if (idx >= 0 && idx < listItems.length) {
+      const input = listItems[idx].querySelector('.file-note-input');
+      if (input) input.value = newNote;
+    }
+  }
+
+  editTagsBtn.addEventListener('click', () => {
+    tagEditing = !tagEditing;
+    if (tagEditing) {
+      editTagsBtn.textContent = 'Confirm';
+      editTagsBtn.classList.add('editing-mode');
+      tagButtons.forEach(btn => {
+        btn.readOnly = false;
+        btn.classList.add('editing');
+      });
+    } else {
+      editTagsBtn.textContent = 'Edit Tags';
+      editTagsBtn.classList.remove('editing-mode');
+      tagButtons.forEach(btn => {
+        btn.readOnly = true;
+        btn.classList.remove('editing');
+      });
+      updateTagButtonStates();
+    }
+  });
+
+  function enterTagMode() {
+    document.body.classList.add('tag-mode-active');
+    toggleTagModeBtn.classList.add('tag-active');
+    wasSidebarEdit = document.getElementById('sidebar').classList.contains('edit-mode');
+    if (!wasSidebarEdit) {
+      document.getElementById('toggleEditBtn').click();
+    }
+    updateTagButtonStates();
+  }
+
+  function exitTagMode() {
+    document.body.classList.remove('tag-mode-active');
+    toggleTagModeBtn.classList.remove('tag-active');
+    if (!wasSidebarEdit && document.getElementById('sidebar').classList.contains('edit-mode')) {
+      document.getElementById('toggleEditBtn').click();
+    }
+  }
+
+  toggleTagModeBtn.addEventListener('click', () => {
+    if (document.body.classList.contains('tag-mode-active')) {
+      exitTagMode();
+    } else {
+      enterTagMode();
+    }
+  });
+
+  document.addEventListener('file-loaded', updateTagButtonStates);
+
+  return { updateTagButtonStates };
+}
+

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -179,6 +179,7 @@
     import { initExportCsv } from './modules/exportCsv.js';
     import { initDragDropLoader } from './modules/dragDropLoader.js';
     import { initSidebar } from './modules/sidebar.js';
+    import { initTagControl } from './modules/tagControl.js';
     import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata } from './modules/fileState.js';
 
     const spectrogramHeight = 800;
@@ -579,7 +580,7 @@
       loadingOverlay.style.display = 'none';
       zoomControlsElem.style.display = 'none';
       guanoOutput.textContent = '(no file selected)';
-      updateTagButtonStates();
+      tagControl.updateTagButtonStates();
     });
 
     const settingBtn = document.getElementById('setting');
@@ -591,119 +592,7 @@
 
     initExportCsv();
 
-    const toggleTagModeBtn = document.getElementById('toggleTagModeBtn');
-      const tagPanel = document.getElementById('tag-panel');
-      const editTagsBtn = document.createElement('button');
-      editTagsBtn.id = 'editTagsBtn';
-      editTagsBtn.textContent = 'Edit Tags';
-      editTagsBtn.className = 'flat-icon-button';
-      const tagButtons = [];
-      const defaultTags = [
-      'JP', 'LP', 'CP', 'KP', 'LBB', 'GBB', 'CN', 'LYB',
-      'HLB', 'ALB', 'CHB', 'IHB', 'LHB',
-      'GBW', 'LBW', 'ABW',
-      'HM', 'RBFM', 'CM', 'WM',
-      'BTB', 'WFTB'
-    ];
-    defaultTags.forEach(tag => {
-      const inp = document.createElement('input');
-      inp.type = 'text';
-      inp.className = 'tag-button';
-      inp.value = tag;
-      inp.readOnly = true;
-      inp.addEventListener('click', () => handleTagClick(inp));
-      tagPanel.appendChild(inp);
-      tagButtons.push(inp);
-    });
-      tagPanel.appendChild(editTagsBtn);
-
-    let wasSidebarEdit = false;
-
-    function updateTagButtonStates() {
-      const idx = getCurrentIndex();
-      const note = idx >= 0 ? getFileNote(idx) : '';
-      const tags = note.split(',').map(t => t.trim()).filter(t => t);
-      tagButtons.forEach(btn => {
-        if (tags.includes(btn.value.trim())) {
-          btn.classList.add('active');
-        } else {
-          btn.classList.remove('active');
-        }
-      });
-    }
-
-    function handleTagClick(btn) {
-      if (!btn.readOnly) return;
-      const idx = getCurrentIndex();
-      if (idx < 0) return;
-      const tag = btn.value.trim();
-      let note = getFileNote(idx);
-      const tags = note ? note.split(',').map(t => t.trim()).filter(t => t) : [];
-      const pos = tags.indexOf(tag);
-      if (pos >= 0) {
-        tags.splice(pos, 1);
-        btn.classList.remove('active');
-      } else {
-        tags.push(tag);
-        btn.classList.add('active');
-      }
-      const newNote = tags.join(', ');
-      setFileNote(idx, newNote);
-      const listItems = document.querySelectorAll('#fileList li');
-      if (idx >= 0 && idx < listItems.length) {
-        const input = listItems[idx].querySelector('.file-note-input');
-        if (input) input.value = newNote;
-      }
-    }
-
-      let tagEditing = false;
-      editTagsBtn.addEventListener('click', () => {
-        tagEditing = !tagEditing;
-        if (tagEditing) {
-          editTagsBtn.textContent = 'Confirm';
-          editTagsBtn.classList.add('editing-mode');
-          tagButtons.forEach(btn => {
-            btn.readOnly = false;
-            btn.classList.add('editing');
-          });
-        } else {
-          editTagsBtn.textContent = 'Edit Tags';
-          editTagsBtn.classList.remove('editing-mode');
-          tagButtons.forEach(btn => {
-            btn.readOnly = true;
-            btn.classList.remove('editing');
-          });
-          updateTagButtonStates();
-        }
-      });
-
-    function enterTagMode() {
-      document.body.classList.add('tag-mode-active');
-      toggleTagModeBtn.classList.add('tag-active');
-      wasSidebarEdit = document.getElementById('sidebar').classList.contains('edit-mode');
-      if (!wasSidebarEdit) {
-        document.getElementById('toggleEditBtn').click();
-      }
-      updateTagButtonStates();
-    }
-
-    function exitTagMode() {
-      document.body.classList.remove('tag-mode-active');
-      toggleTagModeBtn.classList.remove('tag-active');
-      if (!wasSidebarEdit && document.getElementById('sidebar').classList.contains('edit-mode')) {
-        document.getElementById('toggleEditBtn').click();
-      }
-    }
-
-    toggleTagModeBtn.addEventListener('click', () => {
-      if (document.body.classList.contains('tag-mode-active')) {
-        exitTagMode();
-      } else {
-        enterTagMode();
-      }
-    });
-
-    document.addEventListener('file-loaded', updateTagButtonStates);
+    const tagControl = initTagControl();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract tag controls into new `tagControl.js`
- import and initialize tag controls in `sonoradar.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c092ea200832aa7db4f05736bc620