### PR TITLE
Add comma restriction for tag editing

### DIFF
--- a/modules/tagControl.js
+++ b/modules/tagControl.js
@@ -26,6 +26,18 @@ export function initTagControl() {
     inp.className = 'tag-button';
     inp.value = tag;
     inp.readOnly = true;
+    inp.addEventListener('keydown', (e) => {
+      if (e.key === ',') {
+        e.preventDefault();
+        alert('Commas are not allowed in tag names.');
+      }
+    });
+    inp.addEventListener('input', (e) => {
+      if (e.target.value.includes(',')) {
+        e.target.value = e.target.value.replace(/,/g, '');
+        alert('Commas are not allowed in tag names.');
+      }
+    });
     inp.addEventListener('click', () => handleTagClick(inp));
     tagPanel.appendChild(inp);
     tagButtons.push(inp);


### PR DESCRIPTION
## Summary
- warn if a user tries to input commas when editing tag labels

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c0c5341a0832a999d8a935485dd9d