### PR TITLE
Add Clear Trash button

### DIFF
--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -79,6 +79,49 @@ export function getFileMetadata(index) {
   return fileMetadata[index] || { date: '', time: '', latitude: '', longitude: '' };
 }
 
+// Return the number of files marked with the trash flag
+export function getTrashFileCount() {
+  return fileList.reduce((cnt, _f, idx) => {
+    return (fileIcons[idx] && fileIcons[idx].trash) ? cnt + 1 : cnt;
+  }, 0);
+}
+
+// Remove all files that are currently flagged as trash. Returns the number of
+// removed files so that callers can decide how to update the UI.
+export function clearTrashFiles() {
+  if (fileList.length === 0) return 0;
+  const prevFile = getCurrentFile();
+  const newList = [];
+  const newIcons = {};
+  const newNotes = {};
+  const newMetadata = {};
+
+  fileList.forEach((file, idx) => {
+    const icon = fileIcons[idx] || {};
+    if (!icon.trash) {
+      const newIndex = newList.length;
+      newList.push(file);
+      if (fileIcons[idx]) newIcons[newIndex] = { ...fileIcons[idx] };
+      if (fileNotes[idx]) newNotes[newIndex] = fileNotes[idx];
+      if (fileMetadata[idx]) newMetadata[newIndex] = fileMetadata[idx];
+    }
+  });
+
+  const removed = fileList.length - newList.length;
+  if (removed > 0) {
+    fileList = newList;
+    fileIcons = newIcons;
+    fileNotes = newNotes;
+    fileMetadata = newMetadata;
+    if (prevFile) {
+      currentIndex = newList.findIndex(f => f === prevFile);
+    } else {
+      currentIndex = -1;
+    }
+  }
+  return removed;
+}
+
 // Remove files that match the given name from the current list. This also resets
 // any stored icon or note state. The currentIndex will be set to -1 so that the
 // caller can decide which file to load next.

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -27,7 +27,8 @@
        <span style="display:flex; align-items:center; gap:4px;">
          <span id="fileCount" style="font-weight: normal;"></span>
          <i id="clearAllBtn" class="fa-regular fa-file" title="Clear File List" style="cursor:pointer; padding-top:1px;"></i>
-       </span>
+         <i id="clearTrashBtn" class="fa-regular fa-trash" title="Clear Trash Files" style="cursor:pointer; padding-top:1px;"></i>
+      </span>
     </div>
       <div id="searchContainer" style="display:flex; align-items:center; gap:4px; margin-bottom:8px;">
         <input type="text" id="searchInput" placeholder="Search files..." style="flex:1;">
@@ -180,7 +181,7 @@
     import { initDragDropLoader } from './modules/dragDropLoader.js';
     import { initSidebar } from './modules/sidebar.js';
     import { initTagControl } from './modules/tagControl.js';
-    import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata } from './modules/fileState.js';
+    import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount } from './modules/fileState.js';
 
     const spectrogramHeight = 800;
     let sidebarControl;
@@ -581,6 +582,32 @@
       zoomControlsElem.style.display = 'none';
       guanoOutput.textContent = '(no file selected)';
       tagControl.updateTagButtonStates();
+    });
+
+    const clearTrashBtn = document.getElementById('clearTrashBtn');
+    clearTrashBtn.addEventListener('click', () => {
+      const count = getTrashFileCount();
+      if (count === 0) return;
+      const confirmClear = confirm(`This will clear ${count} trash flagged file(s) from the list. Continue?`);
+      if (!confirmClear) return;
+      const removed = clearTrashFiles();
+      if (removed > 0) {
+        sidebarControl.refresh('');
+        if (getFileList().length === 0) {
+          replacePlugin(
+            getCurrentColorMap(),
+            spectrogramHeight,
+            currentFreqMin,
+            currentFreqMax,
+            getOverlapPercent()
+          );
+          showDropOverlay();
+          loadingOverlay.style.display = 'none';
+          zoomControlsElem.style.display = 'none';
+          guanoOutput.textContent = '(no file selected)';
+        }
+        tagControl.updateTagButtonStates();
+      }
     });
 
     const settingBtn = document.getElementById('setting');


### PR DESCRIPTION
## Summary
- extend fileState with trash management helpers
- add Clear Trash button to sidebar
- wire up clearing logic with confirmation prompt

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c11cee4c4832aa31d1e4dd8d364d7