### PR TITLE
Modify hover hide logic based on expand mode

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -10,7 +10,8 @@ export function initFrequencyHover({
   minFrequency = 0,
   totalDuration = 1000,
   getZoomLevel,
-  getDuration
+  getDuration,
+  isExpandMode = () => false
 }) {
   const viewer = document.getElementById(viewerId);
   const wrapper = document.getElementById(wrapperId);
@@ -52,7 +53,7 @@ export function initFrequencyHover({
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
 
-    if (y > (viewer.clientHeight - scrollbarThickness)) {
+    if (isExpandMode() && y > (viewer.clientHeight - scrollbarThickness)) {
       hideAll();
       return;
     }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -381,7 +381,8 @@
           minFrequency: currentFreqMin,
           totalDuration: duration,
           getZoomLevel: () => zoomControl.getZoomLevel(),
-          getDuration: () => duration
+          getDuration: () => duration,
+          isExpandMode: () => zoomControl.isExpandMode()
         });
       } else {
         freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);


### PR DESCRIPTION
## Summary
- add `isExpandMode` option to frequencyHover
- only hide hover elements near scrollbar when expand mode is active
- wire up zoom control's expand state in the HTML

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684c25ad4060832a93fbf5eed1acdfd2