### PR TITLE
Adjust hover behavior near scrollbar

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -24,6 +24,7 @@ export function initFrequencyHover({
   const persistentLines = [];
   const selections = [];
   let persistentLinesEnabled = true;
+  let disablePersistentLinesForScrollbar = false;
   const defaultScrollbarThickness = 20;
   const getScrollbarThickness = () => isExpandMode() ? defaultScrollbarThickness : 0;
   const edgeThreshold = 5;
@@ -56,8 +57,12 @@ export function initFrequencyHover({
 
     if (y > (viewer.clientHeight - getScrollbarThickness())) {
       hideAll();
+      viewer.classList.remove('hide-cursor');
+      disablePersistentLinesForScrollbar = true;
       return;
     }
+    disablePersistentLinesForScrollbar = false;
+    viewer.classList.add('hide-cursor');
 
     const scrollLeft = viewer.scrollLeft || 0;
     const freq = (1 - y / spectrogramHeight) * (maxFrequency - minFrequency) + minFrequency;
@@ -161,7 +166,7 @@ export function initFrequencyHover({
   });
 
   viewer.addEventListener('contextmenu', (e) => {
-    if (!persistentLinesEnabled || isOverTooltip) return;
+    if (!persistentLinesEnabled || disablePersistentLinesForScrollbar || isOverTooltip) return;
     e.preventDefault();
     const rect = fixedOverlay.getBoundingClientRect();
     const y = e.clientY - rect.top;


### PR DESCRIPTION
## Summary
- fix mouse hover logic so that when moving into the scrollbar area the cursor is restored and persistent line drawing is disabled
- guard contextmenu for persistent lines when hovering over the scrollbar

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c2a8ffde8832a9334c03f52b5b445