### PR TITLE
Add FFT size selection

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -68,7 +68,7 @@ export function initDragDropLoader({
     const sampleRate = wavesurfer?.options?.sampleRate || 256000;
     if (spectrogramSettings) {
       spectrogramSettings.textContent =
-        `Sampling rate: ${sampleRate / 1000}kHz, FFT size: 1024, Overlap size: Auto, Hanning window`;
+        `Sampling rate: ${sampleRate / 1000}kHz`;
     }
 
     if (typeof onAfterLoad === 'function') {

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -60,7 +60,7 @@ export function initFileLoader({
     const sampleRate = wavesurfer?.options?.sampleRate || 256000;
     if (spectrogramSettings) {
       spectrogramSettings.textContent =
-        `Sampling rate: ${sampleRate / 1000}kHz, FFT size: 1024, Overlap size: Auto, Hanning window`;
+        `Sampling rate: ${sampleRate / 1000}kHz`;
     }
 
     if (typeof onAfterLoad === 'function') {

--- a/modules/wsManager.js
+++ b/modules/wsManager.js
@@ -6,6 +6,7 @@ import Spectrogram from './spectrogram.esm.js';
 let ws = null;
 let plugin = null;
 let currentColorMap = null;
+let currentFftSize = 1024;
 
 export function initWavesurfer({
   container,
@@ -29,12 +30,13 @@ export function createSpectrogramPlugin({
   height = 800,
   frequencyMin = 10,
   frequencyMax = 128,
+  fftSamples = 1024,
   noverlap = null,
 }) {
   const baseOptions = {
     labels: false,
     height,
-    fftSamples: 1024,
+    fftSamples,
     frequencyMin: frequencyMin * 1000,
     frequencyMax: frequencyMax * 1000,
     scale: 'linear',
@@ -55,7 +57,8 @@ export function replacePlugin(
   frequencyMin = 10,
   frequencyMax = 128,
   overlapPercent = null,
-  onRendered = null  // ✅ 傳入 callback
+  onRendered = null,  // ✅ 傳入 callback
+  fftSamples = currentFftSize
 ) {
   if (!ws) throw new Error('Wavesurfer not initialized.');
   const container = document.getElementById("spectrogram-only");
@@ -67,7 +70,7 @@ export function replacePlugin(
 
   currentColorMap = colorMap;
 
-  const fftSamples = 1024;
+  currentFftSize = fftSamples;
   const noverlap = overlapPercent !== null
     ? Math.floor(fftSamples * (overlapPercent / 100))
     : null;
@@ -77,6 +80,7 @@ export function replacePlugin(
     height,
     frequencyMin,
     frequencyMax,
+    fftSamples,
     noverlap,
   });
 
@@ -102,4 +106,8 @@ export function getPlugin() {
 
 export function getCurrentColorMap() {
   return currentColorMap;
+}
+
+export function getCurrentFftSize() {
+  return currentFftSize;
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -68,6 +68,13 @@
       </div>
       <!-- Tool Bar -->    
       <div id="tool-bar">
+        <label class="slider-label">FFT size:
+          <select id="fftSizeInput" class="styled-select">
+            <option value="512">512</option>
+            <option value="1024" selected>1024</option>
+            <option value="2048">2048</option>
+          </select>
+        </label>
         <label class="slider-label">Overlap:
           <select id="overlapInput" class="styled-select">
             <option value="auto" selected>Auto</option>
@@ -200,7 +207,8 @@
     let duration = 0;
     let currentFreqMin = 10;
     let currentFreqMax = 128;
-    let currentSampleRate = 256000;    
+    let currentSampleRate = 256000;
+    let currentFftSize = 1024;
     let freqHoverControl = null;
     const getDuration = () => duration;
 
@@ -265,6 +273,7 @@
       onAfterLoad: () => {
         loadingOverlay.style.display = 'none';
         freqHoverControl?.refreshHover();
+        updateSpectrogramSettingsText();
       }
     });
     sidebarControl = initSidebar({
@@ -443,6 +452,7 @@
       onAfterLoad: () => {
         loadingOverlay.style.display = 'none';
         freqHoverControl?.refreshHover();
+        updateSpectrogramSettingsText();
       }
     });
 
@@ -489,7 +499,7 @@
     function updateSpectrogramSettingsText() {
       const settingBox = document.getElementById('spectrogram-settings');
       const sampleRate = currentSampleRate;
-      const fftSize = 1024;
+      const fftSize = currentFftSize;
       const overlap = getOverlapPercent();
       const windowType = 'Hanning';
     
@@ -523,6 +533,30 @@
       document.getElementById('fileInput').click();
     });
     
+    document.getElementById('fftSizeInput').addEventListener('change', () => {
+      const val = parseInt(document.getElementById('fftSizeInput').value, 10);
+      if (!isNaN(val)) {
+        currentFftSize = val;
+        const colorMap = getCurrentColorMap();
+        freqHoverControl?.hideHover();
+        replacePlugin(
+          colorMap,
+          spectrogramHeight,
+          currentFreqMin,
+          currentFreqMax,
+          getOverlapPercent(),
+          () => {
+            duration = getWavesurfer().getDuration();
+            zoomControl.applyZoom();
+            renderAxes();
+            freqHoverControl?.refreshHover();
+          },
+          currentFftSize
+        );
+        updateSpectrogramSettingsText();
+      }
+    });
+
     document.getElementById('overlapInput').addEventListener('change', () => {
       const colorMap = getCurrentColorMap();
       freqHoverControl?.hideHover();
@@ -535,7 +569,7 @@
       );
 
       freqHoverControl?.refreshHover();
-          
+
       duration = getWavesurfer().getDuration();
       zoomControl.applyZoom();
       renderAxes();
@@ -561,10 +595,11 @@
     duration = getWavesurfer().getDuration();
     zoomControl.applyZoom();
       renderAxes();
-      
+
       if (freqHoverControl) {
         freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
       }
+      updateSpectrogramSettingsText();
     }
 
     const clearAllBtn = document.getElementById('clearAllBtn');


### PR DESCRIPTION
## Summary
- add FFT size dropdown to toolbar
- allow spectrogram plugin to handle variable FFT size
- sync spectrogram-setting content with FFT size changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686527a4e4e0832a9c6c4e4a3fb86daa