### PR TITLE
Add modular dropdown component

### DIFF
--- a/modules/dropdown.js
+++ b/modules/dropdown.js
@@ -1,0 +1,142 @@
+// modules/dropdown.js
+
+export class Dropdown {
+  constructor(button, items = [], { onChange } = {}) {
+    this.button = button;
+    this.items = items;
+    this.onChange = onChange;
+    this.menu = this._createMenu();
+    this.isOpen = false;
+    this.selectedIndex = -1;
+    this._bindButton();
+  }
+
+  _createMenu() {
+    const menu = document.createElement('div');
+    menu.className = 'dropdown-menu';
+    menu.tabIndex = -1;
+    this.items.forEach((item, index) => {
+      const option = document.createElement('div');
+      option.className = 'dropdown-item';
+      option.textContent = item.label ?? item;
+      option.dataset.index = index;
+      option.addEventListener('click', () => {
+        this.select(index);
+        this.close();
+      });
+      menu.appendChild(option);
+    });
+    document.body.appendChild(menu);
+    return menu;
+  }
+
+  _bindButton() {
+    this.button.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.toggle();
+    });
+    this.button.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        this.open();
+      }
+    });
+  }
+
+  _bindDocument() {
+    this._docHandler = (e) => {
+      if (!this.menu.contains(e.target) && e.target !== this.button) {
+        this.close();
+      }
+    };
+    document.addEventListener('mousedown', this._docHandler);
+    document.addEventListener('touchstart', this._docHandler);
+    document.addEventListener('keydown', (e) => {
+      if (!this.isOpen) return;
+      if (e.key === 'Escape') {
+        this.close();
+      } else if (e.key === 'ArrowDown') {
+        this._move(1);
+        e.preventDefault();
+      } else if (e.key === 'ArrowUp') {
+        this._move(-1);
+        e.preventDefault();
+      } else if (e.key === 'Enter') {
+        if (this.highlightedIndex != null) {
+          this.select(this.highlightedIndex);
+          this.close();
+        }
+      }
+    });
+  }
+
+  _unbindDocument() {
+    document.removeEventListener('mousedown', this._docHandler);
+    document.removeEventListener('touchstart', this._docHandler);
+  }
+
+  _move(dir) {
+    const items = Array.from(this.menu.querySelectorAll('.dropdown-item'));
+    if (items.length === 0) return;
+    if (this.highlightedIndex == null) {
+      this.highlightedIndex = 0;
+    } else {
+      this.highlightedIndex = (this.highlightedIndex + dir + items.length) % items.length;
+    }
+    items.forEach((el, idx) => {
+      el.classList.toggle('highlighted', idx === this.highlightedIndex);
+    });
+    items[this.highlightedIndex].scrollIntoView({ block: 'nearest' });
+  }
+
+  open() {
+    if (this.isOpen) return;
+    this.isOpen = true;
+    const rect = this.button.getBoundingClientRect();
+    this.menu.style.minWidth = rect.width + 'px';
+    this.menu.style.left = rect.left + window.scrollX + 'px';
+    this.menu.style.top = rect.bottom + window.scrollY + 'px';
+    this.menu.style.display = 'block';
+    this.highlightedIndex = this.selectedIndex;
+    const items = Array.from(this.menu.querySelectorAll('.dropdown-item'));
+    items.forEach((el, idx) => {
+      el.classList.toggle('selected', idx === this.selectedIndex);
+    });
+    this._bindDocument();
+    this.menu.focus();
+  }
+
+  close() {
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    this.menu.style.display = 'none';
+    this._unbindDocument();
+    this.button.focus();
+  }
+
+  toggle() {
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  select(index) {
+    this.selectedIndex = index;
+    const value = this.items[index];
+    const label = value.label ?? value;
+    this.button.textContent = label;
+    const items = Array.from(this.menu.querySelectorAll('.dropdown-item'));
+    items.forEach((el, idx) => {
+      el.classList.toggle('selected', idx === index);
+    });
+    if (this.onChange) this.onChange(value, index);
+  }
+}
+
+export function initDropdown(buttonId, items, options) {
+  const btn = typeof buttonId === 'string' ? document.getElementById(buttonId) : buttonId;
+  return new Dropdown(btn, items, options);
+}
+

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -69,31 +69,14 @@
       <!-- Tool Bar -->    
       <div id="tool-bar">
         <label class="slider-label">Fs:
-          <select id="sampleRateInput" class="styled-select">
-            <option value="96000">96</option>
-            <option value="192000">192</option>
-            <option value="256000" selected>256</option>
-            <option value="384000">384</option>
-            <option value="500000">500</option>
-          </select>
+          <button id="sampleRateInput" class="dropdown-button">256</button>
         </label>
         <label class="slider-label">FFT size:
-          <select id="fftSizeInput" class="styled-select">
-            <option value="512">512</option>
-            <option value="1024" selected>1024</option>
-            <option value="2048">2048</option>
-          </select>
+          <button id="fftSizeInput" class="dropdown-button">1024</button>
         </label>
         <label class="slider-label">Overlap:
-          <select id="overlapInput" class="styled-select">
-            <option value="auto" selected>Auto</option>
-            <option value="25">25%</option>
-            <option value="50">50%</option>
-            <option value="75">75%</option>
-            <option value="90">90%</option>
-            <option value="95">95%</option>
-          </select>
-        </label>    
+          <button id="overlapInput" class="dropdown-button">Auto</button>
+        </label>
         <label class="slider-label">F.Range:
           <input type="number" id="freqMinInput" title="Minimun frequency (kHz)" value="10" min="0" max="192" step="1" style="width: 40px; padding-right:0px"> -
           <input type="number" id="freqMaxInput" title="Maximum frequency (kHz)" value="128" min="1" max="192" step="1" style="width: 40px; padding-right:0px">
@@ -191,6 +174,7 @@
     import { initDragDropLoader } from './modules/dragDropLoader.js';
     import { initSidebar } from './modules/sidebar.js';
     import { initTagControl } from './modules/tagControl.js';
+    import { initDropdown } from './modules/dropdown.js';
     import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
     const spectrogramHeight = 800;
@@ -212,6 +196,7 @@
     let currentFreqMax = 128;
     let currentSampleRate = 256000;
     let currentFftSize = 1024;
+    let currentOverlap = 'auto';
     let freqHoverControl = null;
     const getDuration = () => duration;
 
@@ -315,35 +300,26 @@
     
     const toggleGridSwitch = document.getElementById('toggleGridSwitch');
 
-    const sampleRateInput = document.getElementById('sampleRateInput');
-
     freqGrid.style.display = 'none';
     toggleGridSwitch.checked = false;
-    sampleRateInput.value = String(currentSampleRate);
-    
     toggleGridSwitch.addEventListener('change', () => {
       freqGrid.style.display = toggleGridSwitch.checked ? 'block' : 'none';
     });
 
-    sampleRateInput.addEventListener('change', () => {
-      currentSampleRate = parseInt(sampleRateInput.value, 10);
-
+    function handleSampleRate(rate) {
+      currentSampleRate = rate;
       const maxFreq = currentSampleRate / 2000;
       freqMaxInput.max = maxFreq;
       freqMinInput.max = maxFreq;
-
       if (parseFloat(freqMaxInput.value) > maxFreq) {
         freqMaxInput.value = maxFreq;
       }
-
       if (currentFreqMax > maxFreq) {
         currentFreqMax = maxFreq;
       }
-
       if (getWavesurfer()) {
         getWavesurfer().options.sampleRate = currentSampleRate;
       }
-
       freqHoverControl?.hideHover();
       replacePlugin(
         getCurrentColorMap(),
@@ -358,9 +334,8 @@
           freqHoverControl?.refreshHover();
         }
       );
-
       updateSpectrogramSettingsText();
-    });
+    }
 
     const renderAxes = () => {
       drawTimeAxis({
@@ -498,6 +473,32 @@
 
     freqMaxInput.max = currentSampleRate / 2000;
     freqMinInput.max = freqMaxInput.max;
+
+    const sampleRateDropdown = initDropdown('sampleRateInput', [
+      { label: '96', value: 96000 },
+      { label: '192', value: 192000 },
+      { label: '256', value: 256000 },
+      { label: '384', value: 384000 },
+      { label: '500', value: 500000 },
+    ], { onChange: (item) => handleSampleRate(item.value) });
+    sampleRateDropdown.select(2);
+
+    const fftSizeDropdown = initDropdown('fftSizeInput', [
+      { label: '512', value: 512 },
+      { label: '1024', value: 1024 },
+      { label: '2048', value: 2048 },
+    ], { onChange: (item) => handleFftSize(item.value) });
+    fftSizeDropdown.select(1);
+
+    const overlapDropdown = initDropdown('overlapInput', [
+      { label: 'Auto', value: 'auto' },
+      { label: '25%', value: 25 },
+      { label: '50%', value: 50 },
+      { label: '75%', value: 75 },
+      { label: '90%', value: 90 },
+      { label: '95%', value: 95 },
+    ], { onChange: (item) => { currentOverlap = item.value; handleOverlapChange(); } });
+    overlapDropdown.select(0);
     
     function updateSpectrogramSettingsText() {
       const settingBox = document.getElementById('spectrogram-settings');
@@ -512,10 +513,8 @@
     }    
     
     function getOverlapPercent() {
-      const select = document.getElementById('overlapInput');
-      const val = select.value;
-      if (val === 'auto') return null;
-      const parsed = parseInt(val, 10);
+      if (currentOverlap === 'auto') return null;
+      const parsed = parseInt(currentOverlap, 10);
       return isNaN(parsed) ? null : parsed;
     }
     
@@ -536,31 +535,28 @@
       document.getElementById('fileInput').click();
     });
     
-    document.getElementById('fftSizeInput').addEventListener('change', () => {
-      const val = parseInt(document.getElementById('fftSizeInput').value, 10);
-      if (!isNaN(val)) {
-        currentFftSize = val;
-        const colorMap = getCurrentColorMap();
-        freqHoverControl?.hideHover();
-        replacePlugin(
-          colorMap,
-          spectrogramHeight,
-          currentFreqMin,
-          currentFreqMax,
-          getOverlapPercent(),
-          () => {
-            duration = getWavesurfer().getDuration();
-            zoomControl.applyZoom();
-            renderAxes();
-            freqHoverControl?.refreshHover();
-          },
-          currentFftSize
-        );
-        updateSpectrogramSettingsText();
-      }
-    });
+    function handleFftSize(size) {
+      currentFftSize = size;
+      const colorMap = getCurrentColorMap();
+      freqHoverControl?.hideHover();
+      replacePlugin(
+        colorMap,
+        spectrogramHeight,
+        currentFreqMin,
+        currentFreqMax,
+        getOverlapPercent(),
+        () => {
+          duration = getWavesurfer().getDuration();
+          zoomControl.applyZoom();
+          renderAxes();
+          freqHoverControl?.refreshHover();
+        },
+        currentFftSize
+      );
+      updateSpectrogramSettingsText();
+    }
 
-    document.getElementById('overlapInput').addEventListener('change', () => {
+    function handleOverlapChange() {
       const colorMap = getCurrentColorMap();
       freqHoverControl?.hideHover();
       replacePlugin(
@@ -577,7 +573,7 @@
       zoomControl.applyZoom();
       renderAxes();
       updateSpectrogramSettingsText();
-    });
+    }
     
     function updateFrequencyRange(freqMin, freqMax) {
       const colorMap = getCurrentColorMap();

--- a/style.css
+++ b/style.css
@@ -250,40 +250,6 @@ input[type="file"]:hover {
   pointer-events: none;
 }
 
-/* === 黑白風格下拉選單樣式 === */
-.styled-select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background-color: white;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 6px 30px 6px 10px;
-  font-family: 'Noto Sans HK', sans-serif;
-  font-size: 14px;
-  color: black;
-  position: relative;
-  background-image: url("data:image/svg+xml,%3Csvg fill='black' viewBox='0 0 24 24' width='18' height='18' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right 10px center;
-  background-size: 18px 18px;
-  cursor: pointer;
-}
-
-.styled-select:focus {
-  outline: none;
-  border-color: black;
-  border-width: 2px;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
-}
-
-/* 下拉選單開啟時的下拉選單樣式（非原生可控） */
-.styled-select option {
-  background: white;
-  color: black;
-  font-size: 14px;
-  padding: 6px;
-}
 
 /* === Grid Control 的 Switch === */
 .switch {
@@ -695,4 +661,58 @@ input.tag-button.editing {
 .branding-subtitle {
    font-size: 9px;
    color: #666;
+}
+
+/* === Custom Dropdown === */
+.dropdown-button {
+  font-size: 14px;
+  padding: 6px 30px 6px 12px;
+  background-color: #e0e0e0;
+  color: #333;
+  border: 1px solid #bbb;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  position: relative;
+  font-family: 'Noto Sans HK', sans-serif;
+}
+.dropdown-button:hover {
+  background-color: #d5d5d5;
+}
+.dropdown-button::after {
+  content: '';
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  margin-top: -3px;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid #333;
+}
+
+.dropdown-menu {
+  position: absolute;
+  display: none;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  padding: 4px 0;
+  z-index: 1000;
+  font-family: 'Noto Sans HK', sans-serif;
+}
+
+.dropdown-item {
+  padding: 6px 20px;
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 14px;
+}
+.dropdown-item:hover,
+.dropdown-item.highlighted {
+  background-color: #f0f0f0;
+}
+.dropdown-item.selected::before {
+  content: '\2713';
+  margin-right: 6px;
+  color: #1a73e8;
 }


### PR DESCRIPTION
## Summary
- implement `Dropdown` class in modules/dropdown.js
- add dropdown styles
- demo dropdown usage in toolbar
- switch sample rate, FFT size and overlap to custom dropdown buttons
- remove old styled-select styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68653707cf98832aaca997ab309f1e35