### PR TITLE
Improve toolbar styling

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -77,18 +77,22 @@
         <label class="slider-label">Overlap:
           <button id="overlapInput" class="dropdown-button">Auto</button>
         </label>
+        <div class="toolbar-divider"></div>
         <label class="slider-label">F.Range:
           <input type="number" id="freqMinInput" title="Minimun frequency (kHz)" value="10" min="0" max="192" step="1" style="width: 40px; padding-right:0px"> -
           <input type="number" id="freqMaxInput" title="Maximum frequency (kHz)" value="128" min="1" max="192" step="1" style="width: 40px; padding-right:0px">
         </label>
-        <button id="applyFreqRangeBtn" title="Apply" class="sidebar-button"><i class="fa-solid fa-check"></i></button>
+        <button id="applyFreqRangeBtn" title="Apply" class="toolbar-button"><i class="fa-solid fa-check"></i></button>
+        <div class="toolbar-divider"></div>
         <i class="fa-solid fa-sun"></i>
         <input type="range" id="brightnessSlider" min="-0.5" max="0.5" step="0.01" value="0" title="Brightness">
         <span class="slider-value" id="brightnessVal">0</span>
+        <div class="toolbar-divider"></div>
         <i class="fa-solid fa-circle-half-stroke"></i>
         <input type="range" id="gainSlider" min="1" max="4" step="0.1" value="2" title="Contrast">
         <span class="slider-value" id="gainVal">2</span>
-        <button id="resetButton" title="Reset to default" class="sidebar-button"><i class="fas fa-rotate-left"></i></button>
+        <div class="toolbar-divider"></div>
+        <button id="resetButton" title="Reset to default" class="toolbar-button"><i class="fas fa-rotate-left"></i></button>
         <label class="slider-label">Grid:
           <label class="switch" title="Show 10kHz Lines">
             <input type="checkbox" id="toggleGridSwitch">

--- a/style.css
+++ b/style.css
@@ -415,6 +415,7 @@ input[type="file"]:hover {
   font-family: 'Noto Sans HK', sans-serif;
   font-size: 13px;
   margin-bottom: 8px;
+  position: relative;
 }
 
 #top-bar {
@@ -425,20 +426,56 @@ input[type="file"]:hover {
 }
 
 #tool-bar {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform: translateX(-50%) scale(0.95);
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   align-items: center;
-  gap: 5px;
+  gap: 12px;
+  padding: 8px 12px;
+  background-color: #fff;
+  border-radius: 30px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid #eee;
+  font-family: 'Noto Sans HK', sans-serif;
   white-space: nowrap;
-  overflow: hidden;
-  width: 100%;
-  max-height: 0;
   opacity: 0;
-  transition: max-height 0.4s ease, opacity 0.4s ease;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  overflow-x: auto;
 }
 
 #tool-bar.open {
-  max-height: 60px;
   opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%) scale(1);
+}
+
+#tool-bar .toolbar-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  border-radius: 20px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#tool-bar .toolbar-button:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+#tool-bar .toolbar-divider {
+  width: 1px;
+  height: 24px;
+  background-color: #ddd;
+  margin: 0 4px;
 }
 
 /* === Sidebar Button === */


### PR DESCRIPTION
## Summary
- redesign settings toolbar as a floating popup
- add dividers and new helper classes
- tweak control bar to position new popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686550b653f8832a9ac21fc9502a2254