### PR TITLE
Fix Tag mode button

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -274,6 +274,7 @@
         hideDropOverlay();
       }
     });
+    const tagControl = initTagControl();
  
     (async () => {
       try {


### PR DESCRIPTION
## Summary
- call initTagControl when loading the main page so that Tag mode button works

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d6bd2e74832a87dabf602938b1cd