### PR TITLE
Update settings button active style

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -695,9 +695,10 @@
 
     const settingBtn = document.getElementById('setting');
     const toolBar = document.getElementById('tool-bar');
-    
+
     settingBtn.addEventListener('click', () => {
-      toolBar.classList.toggle('open');
+      const isOpen = toolBar.classList.toggle('open');
+      document.body.classList.toggle('settings-open', isOpen);
     });
 
     initExportCsv();

--- a/style.css
+++ b/style.css
@@ -626,6 +626,10 @@ body.tag-mode-active #toggleTagModeBtn {
   background-color: #007bff;
 }
 
+body.settings-open #setting {
+  background-color: #007bff;
+}
+
 input.tag-button {
   width: 90px;
   margin-bottom: 4px;


### PR DESCRIPTION
## Summary
- apply blue active style to settings button when toolbar is open
- toggle a `settings-open` class on `<body>` to control this style

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865d98728cc832ab326364ae728e89b