### PR TITLE
Show spinner for spectrogram redraw

### DIFF
--- a/modules/wsManager.js
+++ b/modules/wsManager.js
@@ -62,6 +62,7 @@ export function replacePlugin(
 ) {
   if (!ws) throw new Error('Wavesurfer not initialized.');
   const container = document.getElementById("spectrogram-only");
+  const loadingOverlay = document.getElementById('loading-overlay');
 
   const oldCanvas = container.querySelector("canvas");
   if (oldCanvas) oldCanvas.remove();
@@ -87,12 +88,15 @@ export function replacePlugin(
   ws.registerPlugin(plugin);
 
   try {
+    if (loadingOverlay) loadingOverlay.style.display = 'flex';
     plugin.render();
     requestAnimationFrame(() => {
+      if (loadingOverlay) loadingOverlay.style.display = 'none';
       if (typeof onRendered === 'function') onRendered();
     });
   } catch (err) {
     console.warn('⚠️ Spectrogram render failed:', err);
+    if (loadingOverlay) loadingOverlay.style.display = 'none';
   }
 }
 

--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -19,6 +19,8 @@ export function initZoomControls(ws, container, duration, applyZoomCallback, wra
 
   function applyZoom() {
     computeMinZoomLevel();
+    const loadingOverlay = document.getElementById('loading-overlay');
+    if (loadingOverlay) loadingOverlay.style.display = 'flex';
     if (typeof onBeforeZoom === 'function') onBeforeZoom();
     zoomLevel = Math.max(zoomLevel, minZoomLevel);
 
@@ -32,8 +34,9 @@ export function initZoomControls(ws, container, duration, applyZoomCallback, wra
     wrapperElement.style.width = `${width}px`;
 
     applyZoomCallback();
-    if (typeof onAfterZoom === 'function') onAfterZoom();    
+    if (typeof onAfterZoom === 'function') onAfterZoom();
     updateZoomButtons();
+    if (loadingOverlay) loadingOverlay.style.display = 'none';
   }
 
   function updateZoomButtons() {


### PR DESCRIPTION
## Summary
- display loading spinner while spectrogram plugin renders
- show same spinner during zoom operations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686668d4baf0832a814eea9d7a3f7573