### PR TITLE
Add draggable map popup

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -1,0 +1,72 @@
+import { getCurrentIndex, getFileMetadata } from './fileState.js';
+
+export function initMapPopup({
+  buttonId = 'mapBtn',
+  popupId = 'mapPopup',
+  mapId = 'map'
+} = {}) {
+  const btn = document.getElementById(buttonId);
+  const popup = document.getElementById(popupId);
+  const mapDiv = document.getElementById(mapId);
+  if (!btn || !popup || !mapDiv) return;
+
+  let map = null;
+  let marker = null;
+
+  function createMap(lat, lon) {
+    map = L.map(mapDiv).setView([lat, lon], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    marker = L.marker([lat, lon]).addTo(map);
+  }
+
+  function updateMap() {
+    const idx = getCurrentIndex();
+    if (idx < 0) return;
+    const meta = getFileMetadata(idx);
+    const lat = parseFloat(meta.latitude);
+    const lon = parseFloat(meta.longitude);
+    if (isNaN(lat) || isNaN(lon)) return;
+
+    if (!map) {
+      createMap(lat, lon);
+    } else {
+      map.setView([lat, lon]);
+      marker.setLatLng([lat, lon]);
+    }
+  }
+
+  function togglePopup() {
+    if (popup.style.display === 'block') {
+      popup.style.display = 'none';
+    } else {
+      popup.style.display = 'block';
+      if (map) {
+        map.invalidateSize();
+      }
+      updateMap();
+    }
+  }
+
+  let dragging = false;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  popup.addEventListener('mousedown', (e) => {
+    dragging = true;
+    offsetX = e.clientX - popup.offsetLeft;
+    offsetY = e.clientY - popup.offsetTop;
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    popup.style.left = `${e.clientX - offsetX}px`;
+    popup.style.top = `${e.clientY - offsetY}px`;
+  });
+
+  window.addEventListener('mouseup', () => { dragging = false; });
+
+  btn.addEventListener('click', togglePopup);
+  document.addEventListener('file-loaded', updateMap);
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -7,7 +7,9 @@
   <link rel="stylesheet" href="style.css" />
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+HK&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="icon" href="./favicon.ico" sizes="any" type="image/x-icon" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
 
@@ -64,6 +66,7 @@
         <button id="nextBtn" title="Next file (↓)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
         <button id="toggleTagModeBtn" title="Tag mode" class="sidebar-button"><i class="fa-solid fa-tags"></i></button>
         <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
+        <button id="mapBtn" title="Map" class="sidebar-button"><i class="fa-solid fa-map-location-dot"></i></button>
         <button id="setting" title="Spectrogram setting" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
       </div>
       <!-- Tool Bar -->    
@@ -152,10 +155,13 @@
       <div id="time-axis"></div>
     </div>
     <div id="time-label">Time (ms)</div>
-  </div>      
+  </div>
     </div>
-<!-------- Spectrogram End -------->     
-  </div>   
+<!-------- Spectrogram End -------->
+  <div id="mapPopup" class="map-popup" style="display:none;">
+    <div id="map" style="width:100%;height:100%;"></div>
+  </div>
+  </div>
   <script type="module">
     import {
       initWavesurfer,
@@ -174,6 +180,7 @@
     import { initScrollSync } from './modules/scrollSync.js';
     import { initExportCsv } from './modules/exportCsv.js';
     import { initDragDropLoader } from './modules/dragDropLoader.js';
+    import { initMapPopup } from './modules/mapPopup.js';
     import { initSidebar } from './modules/sidebar.js';
     import { initTagControl } from './modules/tagControl.js';
     import { initDropdown } from './modules/dropdown.js';
@@ -700,6 +707,7 @@
     });
 
     initExportCsv();
+    initMapPopup();
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -760,3 +760,18 @@ input.tag-button.editing {
   margin-right: 6px;
   color: #1a73e8;
 }
+
+/* === Map Popup === */
+.map-popup {
+  position: absolute;
+  top: 80px;
+  left: 80px;
+  width: 500px;
+  height: 500px;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  z-index: 1000;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  cursor: move;
+}


### PR DESCRIPTION
## Summary
- add Leaflet CSS & script to head
- add Map button next to Export on top bar
- include draggable map popup container
- style `.map-popup`
- implement map popup logic in new module
- initialize map popup in main script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686698a63be8832ab81de40ff6f2586e