### PR TITLE
Enhance map popup

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -9,6 +9,7 @@ export function initMapPopup({
   const popup = document.getElementById(popupId);
   const mapDiv = document.getElementById(mapId);
   const dragBar = popup.querySelector('.popup-drag-bar');
+  const closeBtn = popup.querySelector('.popup-close-btn');
   if (!btn || !popup || !mapDiv) return;
   mapDiv.style.cursor = 'grab';
 
@@ -82,5 +83,8 @@ export function initMapPopup({
   });
 
   btn.addEventListener('click', togglePopup);
+  if (closeBtn) {
+    closeBtn.addEventListener('click', togglePopup);
+  }
   document.addEventListener('file-loaded', updateMap);
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -159,7 +159,9 @@
     </div>
 <!-------- Spectrogram End -------->
   <div id="mapPopup" class="map-popup" style="display:none;">
-    <div class="popup-drag-bar">Map</div>
+    <div class="popup-drag-bar">
+      <button class="popup-close-btn" title="Close">&times;</button>
+    </div>
     <div id="map" style="width:100%;height:calc(100% - 30px);"></div>
   </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -772,8 +772,10 @@ input.tag-button.editing {
   left: 80px;
   width: 500px;
   height: 500px;
-  background: #fff;
-  border: 1px solid #ccc;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   border-radius: 8px;
   z-index: 1000;
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
@@ -781,13 +783,29 @@ input.tag-button.editing {
 }
 
 .popup-drag-bar {
+  position: relative;
   height: 30px;
   line-height: 30px;
-  padding-left: 10px;
-  background: #f7f7f7;
-  border-bottom: 1px solid #ccc;
+  background: rgba(255, 255, 255, 0.5);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
   cursor: move;
   user-select: none;
+}
+
+.popup-close-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+}
+.popup-close-btn:hover {
+  color: #c00;
 }


### PR DESCRIPTION
## Summary
- use frosted glass effect on map popup
- add close button in map popup drag bar
- remove title text from drag bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866a912fda8832aa991395d6e774728