### PR TITLE
Allow resizing map popup

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -13,6 +13,12 @@ export function initMapPopup({
   if (!btn || !popup || !mapDiv) return;
   mapDiv.style.cursor = 'grab';
 
+  const edgeThreshold = 5;
+  let popupWidth = parseInt(localStorage.getItem('mapPopupWidth')) || popup.offsetWidth;
+  let popupHeight = parseInt(localStorage.getItem('mapPopupHeight')) || popup.offsetHeight;
+  popup.style.width = `${popupWidth}px`;
+  popup.style.height = `${popupHeight}px`;
+
   let map = null;
   let marker = null;
 
@@ -47,6 +53,8 @@ export function initMapPopup({
     } else {
       popup.style.display = 'block';
       document.body.classList.add('map-open');
+      popup.style.width = `${popupWidth}px`;
+      popup.style.height = `${popupHeight}px`;
       if (map) {
         map.invalidateSize();
       }
@@ -57,6 +65,11 @@ export function initMapPopup({
   let dragging = false;
   let offsetX = 0;
   let offsetY = 0;
+  let resizing = false;
+  let resizeLeft = false;
+  let resizeRight = false;
+  let resizeTop = false;
+  let resizeBottom = false;
 
   if (dragBar) {
     dragBar.addEventListener('mousedown', (e) => {
@@ -69,16 +82,91 @@ export function initMapPopup({
     });
   }
 
+  popup.addEventListener('mousemove', (e) => {
+    if (dragging || resizing) return;
+    const rect = popup.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const onLeft = x < edgeThreshold;
+    const onRight = x > rect.width - edgeThreshold;
+    const onTop = y < edgeThreshold;
+    const onBottom = y > rect.height - edgeThreshold;
+    let cursor = 'default';
+    if ((onLeft && onTop) || (onRight && onBottom)) {
+      cursor = 'nwse-resize';
+    } else if ((onRight && onTop) || (onLeft && onBottom)) {
+      cursor = 'nesw-resize';
+    } else if (onLeft || onRight) {
+      cursor = 'ew-resize';
+    } else if (onTop || onBottom) {
+      cursor = 'ns-resize';
+    }
+    popup.style.cursor = cursor;
+  });
+
+  popup.addEventListener('mousedown', (e) => {
+    if (e.target === dragBar || dragBar.contains(e.target)) return;
+    const rect = popup.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const onLeft = x < edgeThreshold;
+    const onRight = x > rect.width - edgeThreshold;
+    const onTop = y < edgeThreshold;
+    const onBottom = y > rect.height - edgeThreshold;
+    if (onLeft || onRight || onTop || onBottom) {
+      resizing = true;
+      resizeLeft = onLeft;
+      resizeRight = onRight;
+      resizeTop = onTop;
+      resizeBottom = onBottom;
+      map?.dragging.disable();
+      e.preventDefault();
+      e.stopPropagation();
+    }
+  });
+
   window.addEventListener('mousemove', (e) => {
-    if (!dragging) return;
-    popup.style.left = `${e.clientX - offsetX}px`;
-    popup.style.top = `${e.clientY - offsetY}px`;
+    if (dragging) {
+      popup.style.left = `${e.clientX - offsetX}px`;
+      popup.style.top = `${e.clientY - offsetY}px`;
+      return;
+    }
+    if (resizing) {
+      const rect = popup.getBoundingClientRect();
+      if (resizeRight) {
+        popupWidth = Math.max(200, e.clientX - rect.left);
+        popup.style.width = `${popupWidth}px`;
+      }
+      if (resizeBottom) {
+        popupHeight = Math.max(200, e.clientY - rect.top);
+        popup.style.height = `${popupHeight}px`;
+      }
+      if (resizeLeft) {
+        const newLeft = e.clientX;
+        popupWidth = Math.max(200, rect.right - newLeft);
+        popup.style.width = `${popupWidth}px`;
+        popup.style.left = `${newLeft}px`;
+      }
+      if (resizeTop) {
+        const newTop = e.clientY;
+        popupHeight = Math.max(200, rect.bottom - newTop);
+        popup.style.height = `${popupHeight}px`;
+        popup.style.top = `${newTop}px`;
+      }
+    }
   });
 
   window.addEventListener('mouseup', () => {
     if (dragging) {
       dragging = false;
       map?.dragging.enable();
+    }
+    if (resizing) {
+      resizing = false;
+      map?.dragging.enable();
+      localStorage.setItem('mapPopupWidth', popupWidth);
+      localStorage.setItem('mapPopupHeight', popupHeight);
+      map?.invalidateSize();
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -780,6 +780,8 @@ input.tag-button.editing {
   z-index: 1000;
   box-shadow: 0 2px 6px rgba(0,0,0,0.3);
   cursor: default;
+  user-select: none;
+  overflow: hidden;
 }
 
 .popup-drag-bar {


### PR DESCRIPTION
## Summary
- persist last popup size in localStorage
- allow resizing map popup from its edges
- keep map popup style from being selectable

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867168a3cbc832aad8b23708fc6b909