### PR TITLE
Add map markers for all files

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -1,4 +1,4 @@
-import { getCurrentIndex, getFileMetadata } from './fileState.js';
+import { getCurrentIndex, getFileMetadata, getFileList } from './fileState.js';
 
 export function initMapPopup({
   buttonId = 'mapBtn',
@@ -48,14 +48,36 @@ export function initMapPopup({
   popup.style.height = `${popupHeight}px`;
 
   let map = null;
-  let marker = null;
+  let markers = [];
 
   function createMap(lat, lon) {
     map = L.map(mapDiv).setView([lat, lon], 13);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
-    marker = L.marker([lat, lon]).addTo(map);
+  }
+
+  function refreshMarkers() {
+    if (!map) return;
+    markers.forEach(m => m.remove());
+    markers = [];
+    const list = getFileList();
+    const curIdx = getCurrentIndex();
+    list.forEach((file, idx) => {
+      const meta = getFileMetadata(idx);
+      const lat = parseFloat(meta.latitude);
+      const lon = parseFloat(meta.longitude);
+      if (isNaN(lat) || isNaN(lon)) return;
+      const cls = idx === curIdx ? 'map-marker-current' : 'map-marker-other';
+      const icon = new L.Icon.Default({ className: cls });
+      const name = file.name.replace(/\.wav$/i, '');
+      const marker = L.marker([lat, lon], { icon, title: name });
+      marker.on('click', () => {
+        document.dispatchEvent(new CustomEvent('map-file-selected', { detail: { index: idx } }));
+      });
+      marker.addTo(map);
+      markers.push(marker);
+    });
   }
 
   function updateMap() {
@@ -70,8 +92,8 @@ export function initMapPopup({
       createMap(lat, lon);
     } else {
       map.setView([lat, lon]);
-      marker.setLatLng([lat, lon]);
     }
+    refreshMarkers();
   }
 
   function togglePopup() {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -711,6 +711,12 @@
 
     initExportCsv();
     initMapPopup();
+    document.addEventListener('map-file-selected', (e) => {
+      const idx = e.detail?.index;
+      if (typeof idx === 'number') {
+        fileLoaderControl.loadFileAtIndex(idx);
+      }
+    });
   </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -811,3 +811,15 @@ input.tag-button.editing {
 .popup-close-btn:hover {
   color: #c00;
 }
+
+.map-marker-other {
+  opacity: 0.5;
+  transform: scale(0.7);
+  transform-origin: bottom center;
+}
+
+.map-marker-current {
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: bottom center;
+}


### PR DESCRIPTION
## Summary
- show all wav files with location info in the map popup
- mark current file differently and allow clicking on a marker to load that file
- add styling for active/inactive markers
- wire up listener in index page to load file when marker clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68672c9b91e0832a8381c0b0cafbf4ac