### PR TITLE
Adjust map marker size

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -72,8 +72,8 @@ export function initMapPopup({
       const icon = L.divIcon({
         html: '<i class="fa-solid fa-location-dot"></i>',
         className: cls,
-        iconSize: [24, 24],
-        iconAnchor: [12, 24]
+        iconSize: [28, 28],
+        iconAnchor: [14, 28]
       });
       const name = file.name.replace(/\.wav$/i, '');
       const zIndexOffset = idx === curIdx ? 1000 : 0;

--- a/style.css
+++ b/style.css
@@ -813,23 +813,25 @@ input.tag-button.editing {
 }
 
 .map-marker-other i{
-  font-size: 24px;
-  line-height: 24px;
+  font-size: 28px;
+  line-height: 28px;
   color: #ffd700;
   opacity: 0.5;
   transform: scale(0.75);
   transform-origin: bottom center;
   pointer-events: none;
   mix-blend-mode: lighten;
+  filter: drop-shadow(0 2px 2px rgba(0,0,0,0.4));
 }
 
 .map-marker-current i{
-  font-size: 24px;
-  line-height: 24px;
+  font-size: 28px;
+  line-height: 28px;
   color: #fa6e02;
   opacity: 1;
   transform: scale(1);
   transform-origin: bottom center;
   pointer-events: none;
   z-index: 1000;
+  filter: drop-shadow(0 2px 2px rgba(0,0,0,0.4));
 }


### PR DESCRIPTION
## Summary
- enlarge map markers by 4px
- add drop-shadow for markers so they mimic Leaflet's default shadow

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686741c4eb10832ab5ec359e99712a45