### PR TITLE
Improve map tooltip

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -94,13 +94,20 @@ export function initMapPopup({
         iconSize: [28, 28],
         iconAnchor: [14, 28]
       });
-      const names = group.map(g => g.file.name.replace(/\.wav$/i, '')).join('<br>');
+      const fileNames = group.map(g => g.file.name.replace(/\.wav$/i, ''));
+      const names = (fileNames.length <= 5)
+        ? fileNames.join('<br>')
+        : `${fileNames[0]}<br>│<br>${fileNames[fileNames.length - 1]}`;
       const zIndexOffset = isCurrent ? 1000 : 0;
-      const marker = L.marker([lat, lon], { icon, title: names, zIndexOffset });
+      const marker = L.marker([lat, lon], { icon, zIndexOffset });
       marker.on('click', () => {
         document.dispatchEvent(new CustomEvent('map-file-selected', { detail: { index: first.idx } }));
       });
-      marker.bindTooltip(names, { direction: 'top' });
+      marker.bindTooltip(names, {
+        direction: 'top',
+        offset: [12, -12],
+        className: 'map-tooltip'
+      });
       marker.addTo(map);
       markers.push(marker);
     });

--- a/style.css
+++ b/style.css
@@ -834,3 +834,12 @@ input.tag-button.editing {
   z-index: 1000;
   filter: drop-shadow(0 2px 2px rgba(0,0,0,0.4));
 }
+
+.map-tooltip {
+  background: #ffffff;
+  color: #000000;
+  border: 1px solid rgba(0,0,0,0.2);
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
- simplify file list display for map markers
- use custom tooltip style positioned slightly above/right of markers
- add `.map-tooltip` CSS to make tooltips white instead of the default black

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68674f46986c832ab3681a7847a110e2