### PR TITLE
Update marker hover effect

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -105,7 +105,7 @@ export function initMapPopup({
       });
       marker.bindTooltip(names, {
         direction: 'top',
-        offset: [12, -12],
+        offset: [0, -32],
         className: 'map-tooltip'
       });
       marker.addTo(map);

--- a/style.css
+++ b/style.css
@@ -823,6 +823,12 @@ input.tag-button.editing {
   filter: drop-shadow(0 2px 2px rgba(0,0,0,0.4));
 }
 
+.map-marker-other:hover i{
+  color: #fa6e02;
+  transform: scale(1);
+  opacity: 0.5;
+}
+
 .map-marker-current i{
   font-size: 28px;
   line-height: 28px;


### PR DESCRIPTION
## Summary
- display map marker tooltips above markers
- change map-marker-other style when hovering over a marker

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68675e16ab5c832abc410a00e0a358f1