### PR TITLE
Ensure zoom resets when switching files

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -717,6 +717,12 @@
         fileLoaderControl.loadFileAtIndex(idx);
       }
     });
+
+    document.addEventListener('file-loaded', () => {
+      if (!zoomControl.isExpandMode() && zoomControl.getZoomLevel() > 1000) {
+        zoomControl.setZoomLevel(1000);
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update HTML to react to `file-loaded` events
- keep zoom <= 1000 when not in Expand mode on file change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867d6ec17ac832aa8640de820c463d8