### PR TITLE
Improve WAV sample rate detection

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -1,6 +1,7 @@
 // modules/dragDropLoader.js
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
+import { getWavSampleRate } from "./wavReader.js";
 import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
 
 export function initDragDropLoader({
@@ -11,7 +12,8 @@ export function initDragDropLoader({
   onPluginReplaced,
   onFileLoaded,
   onBeforeLoad,
-  onAfterLoad
+  onAfterLoad,
+  onSampleRateDetected
 }) {
   const dropArea = document.getElementById(targetElementId);
   const overlay = document.getElementById('drop-overlay');
@@ -33,6 +35,7 @@ export function initDragDropLoader({
   async function loadFile(file) {
     if (!file) return;
 
+    const detectedSampleRate = await getWavSampleRate(file);
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
     }    
@@ -65,7 +68,12 @@ export function initDragDropLoader({
       onPluginReplaced();
     }
 
-    const sampleRate = wavesurfer?.options?.sampleRate || 256000;
+      const sampleRate = detectedSampleRate || wavesurfer?.options?.sampleRate || 256000;
+
+    if (typeof onSampleRateDetected === 'function') {
+      await onSampleRateDetected(sampleRate);
+    }
+
     if (spectrogramSettings) {
       spectrogramSettings.textContent =
         `Sampling rate: ${sampleRate / 1000}kHz`;

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -1,6 +1,7 @@
 // modules/fileLoader.js
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
+import { getWavSampleRate } from "./wavReader.js";
 import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
 
 let lastObjectUrl = null;
@@ -13,7 +14,8 @@ export function initFileLoader({
   onPluginReplaced,
   onFileLoaded,
   onBeforeLoad,
-  onAfterLoad
+  onAfterLoad,
+  onSampleRateDetected
 }) {
   const fileInput = document.getElementById(fileInputId);
   const prevBtn = document.getElementById('prevBtn');
@@ -24,6 +26,7 @@ export function initFileLoader({
 
   async function loadFile(file) {
     if (!file) return;
+    const detectedSampleRate = await getWavSampleRate(file);
 
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
@@ -57,7 +60,12 @@ export function initFileLoader({
       onPluginReplaced();
     }
 
-    const sampleRate = wavesurfer?.options?.sampleRate || 256000;
+    const sampleRate = detectedSampleRate || wavesurfer?.options?.sampleRate || 256000;
+
+    if (typeof onSampleRateDetected === 'function') {
+      await onSampleRateDetected(sampleRate);
+    }
+
     if (spectrogramSettings) {
       spectrogramSettings.textContent =
         `Sampling rate: ${sampleRate / 1000}kHz`;

--- a/modules/wavReader.js
+++ b/modules/wavReader.js
@@ -1,0 +1,21 @@
+export async function getWavSampleRate(file) {
+  if (!file) return 256000;
+  const buffer = await file.arrayBuffer();
+  const view = new DataView(buffer);
+  let pos = 12;
+  while (pos < view.byteLength - 8) {
+    const chunkId = String.fromCharCode(
+      view.getUint8(pos),
+      view.getUint8(pos + 1),
+      view.getUint8(pos + 2),
+      view.getUint8(pos + 3)
+    );
+    const chunkSize = view.getUint32(pos + 4, true);
+    if (chunkId === 'fmt ') {
+      return view.getUint32(pos + 12, true);
+    }
+    pos += 8 + chunkSize;
+    if (chunkSize % 2 === 1) pos += 1; // word alignment
+  }
+  return 256000;
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -207,6 +207,7 @@
     let currentFreqMin = 10;
     let currentFreqMax = 128;
     let currentSampleRate = 256000;
+    let selectedSampleRate = 'auto';
     let currentFftSize = 1024;
     let currentOverlap = 'auto';
     let freqHoverControl = null;
@@ -274,7 +275,8 @@
         loadingOverlay.style.display = 'none';
         freqHoverControl?.refreshHover();
         updateSpectrogramSettingsText();
-      }
+      },
+      onSampleRateDetected: autoSetSampleRate
     });
     sidebarControl = initSidebar({
       onFileSelected: (index) => {
@@ -319,7 +321,7 @@
       freqGrid.style.display = toggleGridSwitch.checked ? 'block' : 'none';
     });
 
-    async function handleSampleRate(rate) {
+    async function applySampleRate(rate) {
       currentSampleRate = rate;
       const maxFreq = currentSampleRate / 2000;
       freqMaxInput.max = maxFreq;
@@ -354,6 +356,23 @@
         }
       );
       updateSpectrogramSettingsText();
+    }
+
+    async function handleSampleRate(rate) {
+      selectedSampleRate = rate;
+      if (rate === 'auto') {
+        updateSpectrogramSettingsText();
+        return;
+      }
+      await applySampleRate(rate);
+    }
+
+    async function autoSetSampleRate(rate) {
+      if (selectedSampleRate === 'auto' && rate && rate !== currentSampleRate) {
+        await applySampleRate(rate);
+      } else if (selectedSampleRate === 'auto') {
+        updateSpectrogramSettingsText();
+      }
     }
 
     const renderAxes = () => {
@@ -450,7 +469,8 @@
         loadingOverlay.style.display = 'none';
         freqHoverControl?.refreshHover();
         updateSpectrogramSettingsText();
-      }
+      },
+      onSampleRateDetected: autoSetSampleRate
     });
 
     initScrollSync({
@@ -494,13 +514,14 @@
     freqMinInput.max = freqMaxInput.max;
 
     const sampleRateDropdown = initDropdown('sampleRateInput', [
+      { label: 'Auto', value: 'auto' },
       { label: '96', value: 96000 },
       { label: '192', value: 192000 },
       { label: '256', value: 256000 },
       { label: '384', value: 384000 },
       { label: '500', value: 500000 },
     ], { onChange: (item) => handleSampleRate(item.value) });
-    sampleRateDropdown.select(2);
+    sampleRateDropdown.select(0);
 
     const fftSizeDropdown = initDropdown('fftSizeInput', [
       { label: '512', value: 512 },


### PR DESCRIPTION
## Summary
- read WAV header to determine sample rate
- use detected rate in file loaders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867ded7e7a4832a89f03a2ba1be4e9c