### PR TITLE
Improve spectrogram load time for varying sample rates

### DIFF
--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -31,9 +31,13 @@ export function initFileLoader({
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
     }
-    
+
     if (typeof onFileLoaded === 'function') {
       onFileLoaded(file);
+    }
+
+    if (typeof onSampleRateDetected === 'function') {
+      await onSampleRateDetected(detectedSampleRate, true);
     }
     
     if (fileNameElem) {
@@ -61,10 +65,6 @@ export function initFileLoader({
     }
 
     const sampleRate = detectedSampleRate || wavesurfer?.options?.sampleRate || 256000;
-
-    if (typeof onSampleRateDetected === 'function') {
-      await onSampleRateDetected(sampleRate);
-    }
 
     if (spectrogramSettings) {
       spectrogramSettings.textContent =

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -321,7 +321,7 @@
       freqGrid.style.display = toggleGridSwitch.checked ? 'block' : 'none';
     });
 
-    async function applySampleRate(rate) {
+    async function applySampleRate(rate, reloadFile = true) {
       const prevRate = currentSampleRate;
       currentSampleRate = rate;
       const maxFreq = currentSampleRate / 2000;
@@ -346,9 +346,11 @@
 
       if (getWavesurfer()) {
         getWavesurfer().options.sampleRate = currentSampleRate;
-        const idx = getCurrentIndex();
-        if (idx >= 0) {
-          await fileLoaderControl.loadFileAtIndex(idx);
+        if (reloadFile) {
+          const idx = getCurrentIndex();
+          if (idx >= 0) {
+            await fileLoaderControl.loadFileAtIndex(idx);
+          }
         }
       }
       freqHoverControl?.hideHover();
@@ -377,9 +379,9 @@
       await applySampleRate(rate);
     }
 
-    async function autoSetSampleRate(rate) {
+    async function autoSetSampleRate(rate, skipReload = false) {
       if (selectedSampleRate === 'auto' && rate && rate !== currentSampleRate) {
-        await applySampleRate(rate);
+        await applySampleRate(rate, !skipReload);
       } else if (selectedSampleRate === 'auto') {
         updateSpectrogramSettingsText();
       }


### PR DESCRIPTION
## Summary
- update `applySampleRate` to optionally skip reloading the current file
- allow `autoSetSampleRate` to pass the reload flag
- detect the WAV sample rate before loading and avoid loading twice

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867f1c34e00832a90fc53d6d628990f