### PR TITLE
Fix map marker refresh

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -81,7 +81,8 @@ export function initDragDropLoader({
 
     if (typeof onAfterLoad === 'function') {
       onAfterLoad();
-    }    
+    }
+    document.dispatchEvent(new Event('file-loaded'));
   }
 
   async function handleFiles(files) {

--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -301,7 +301,10 @@ export function initMapPopup({
 
   function updateMap() {
     const idx = getCurrentIndex();
-    if (idx < 0) return;
+    if (idx < 0) {
+      refreshMarkers();
+      return;
+    }
     const meta = getFileMetadata(idx);
     const lat = parseFloat(meta.latitude);
     const lon = parseFloat(meta.longitude);
@@ -473,4 +476,5 @@ export function initMapPopup({
     closeBtn.addEventListener('click', togglePopup);
   }
   document.addEventListener('file-loaded', updateMap);
+  document.addEventListener('file-list-cleared', () => refreshMarkers());
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -669,6 +669,7 @@
       zoomControlsElem.style.display = 'none';
       guanoOutput.textContent = '(no file selected)';
       tagControl.updateTagButtonStates();
+      document.dispatchEvent(new Event('file-list-cleared'));
     });
 
     const clearTrashBtn = document.getElementById('clearTrashBtn');


### PR DESCRIPTION
## Summary
- ensure drag and drop triggers `file-loaded`
- refresh map markers when file list is cleared
- clear markers if no file is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867f98ac844832a997ebd105066cedc