### PR TITLE
Update max frequency behavior on sample rate change

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -328,10 +328,9 @@
       freqMaxInput.max = maxFreq;
       freqMinInput.max = maxFreq;
 
-      const shouldAdjustRange =
-        selectedSampleRate !== 'auto' || rate < prevRate;
+      const isManual = selectedSampleRate !== 'auto';
 
-      if (shouldAdjustRange) {
+      if (isManual && rate < prevRate) {
         freqMaxInput.value = maxFreq;
       } else if (parseFloat(freqMaxInput.value) > maxFreq) {
         freqMaxInput.value = maxFreq;


### PR DESCRIPTION
## Summary
- tweak `applySampleRate` so manual sample rate increases keep existing frequency range

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867fc708f98832ab606cd64f61a5f2d