### PR TITLE
Auto detect sample rate when switching to auto mode

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -177,7 +177,7 @@
     } from './modules/wsManager.js';
 
     import { initZoomControls } from './modules/zoomControl.js';
-    import { initFileLoader } from './modules/fileLoader.js';
+    import { initFileLoader, getWavSampleRate } from './modules/fileLoader.js';
     import { initBrightnessControl } from './modules/brightnessControl.js';
     import { initFrequencyHover } from './modules/frequencyHover.js';
     import { drawTimeAxis, drawFrequencyGrid } from './modules/axisRenderer.js';
@@ -372,7 +372,13 @@
     async function handleSampleRate(rate) {
       selectedSampleRate = rate;
       if (rate === 'auto') {
-        updateSpectrogramSettingsText();
+        const cur = getCurrentFile();
+        if (cur) {
+          const autoRate = await getWavSampleRate(cur);
+          await autoSetSampleRate(autoRate);
+        } else {
+          updateSpectrogramSettingsText();
+        }
         return;
       }
       await applySampleRate(rate);


### PR DESCRIPTION
## Summary
- auto-detect current WAV file's sample rate when switching sample rate selector to auto
- reload the file so the spectrogram updates with the detected rate

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6867ff289598832a809fdf371ef7714b