### PR TITLE
Fix auto sample rate switch

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -375,7 +375,7 @@
         const cur = getCurrentFile();
         if (cur) {
           const autoRate = await getWavSampleRate(cur);
-          await autoSetSampleRate(autoRate, true);
+          await autoSetSampleRate(autoRate);
         } else {
           updateSpectrogramSettingsText();
         }


### PR DESCRIPTION
## Summary
- switch to auto sample rate now reloads spectrogram with detected WAV rate

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686804891ff4832aa9d59143a0a879a3