### PR TITLE
Fix zoom level adjustment on sampling rate change

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -381,7 +381,7 @@
         }
         return;
       }
-      await applySampleRate(rate);
+      await applySampleRate(rate, false);
     }
 
     async function autoSetSampleRate(rate, skipReload = false) {


### PR DESCRIPTION
## Summary
- avoid reloading current file on manual sample rate change
- keep existing zoom level when changing sampling rate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68680682b7cc832a94706dffd0c5524a