### PR TITLE
Allow zoom >1000 when reloading same file

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -204,6 +204,7 @@
     const hoverLabelElem = document.getElementById('hover-label');
     const zoomControlsElem = document.getElementById('zoom-controls');
     let duration = 0;
+    let lastLoadedFileName = null;
     let currentFreqMin = 10;
     let currentFreqMax = 128;
     let currentSampleRate = 256000;
@@ -758,13 +759,16 @@
     });
 
     document.addEventListener('file-loaded', () => {
+      const currentFile = getCurrentFile();
       duration = getWavesurfer().getDuration();
       if (duration > 8) {
         // force minimum zoom level for long recordings
         zoomControl.setZoomLevel(0);
-      } else if (!zoomControl.isExpandMode() && zoomControl.getZoomLevel() > 1000) {
+      } else if (currentFile && currentFile.name !== lastLoadedFileName &&
+                 !zoomControl.isExpandMode() && zoomControl.getZoomLevel() > 1000) {
         zoomControl.setZoomLevel(1000);
       }
+      lastLoadedFileName = currentFile ? currentFile.name : null;
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- track the last loaded file name
- prevent zoom level from resetting to 1000 when the same WAV file is reloaded

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68687fd18ab8832ab17fa4d28c35fae4