### PR TITLE
Add device location view for empty map

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -299,10 +299,32 @@ export function initMapPopup({
     }
   }
 
+  function showDeviceLocation() {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition((pos) => {
+      const { latitude: lat, longitude: lon } = pos.coords;
+      const icon = L.divIcon({
+        html: '<i class="fa-solid fa-location-crosshairs"></i>',
+        className: 'map-marker-device',
+        iconSize: [28, 28],
+        iconAnchor: [14, 28]
+      });
+      if (!map) {
+        createMap(lat, lon);
+      } else {
+        map.setView([lat, lon]);
+      }
+      const marker = L.marker([lat, lon], { icon, zIndexOffset: 1001 });
+      marker.addTo(map);
+      markers.push(marker);
+    });
+  }
+
   function updateMap() {
     const idx = getCurrentIndex();
     if (idx < 0) {
       refreshMarkers();
+      showDeviceLocation();
       return;
     }
     const meta = getFileMetadata(idx);

--- a/style.css
+++ b/style.css
@@ -841,6 +841,17 @@ input.tag-button.editing {
   filter: drop-shadow(0 2px 2px rgba(0,0,0,0.4));
 }
 
+.map-marker-device i{
+  font-size: 28px;
+  line-height: 28px;
+  color: #4285f4;
+  opacity: 1;
+  transform: scale(1);
+  transform-origin: bottom center;
+  pointer-events: none;
+  filter: drop-shadow(0 2px 2px rgba(0,0,0,0.4));
+}
+
 .map-tooltip {
   background: #ffffff;
   color: #000000;


### PR DESCRIPTION
## Summary
- show device location when the map opens without any loaded files
- style marker for device position

## Testing
- `npm test` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_686884d5ae6c832a96488b715fe0f88e