### PR TITLE
Add KML drag-and-drop on map

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -59,6 +59,59 @@ export function initMapPopup({
   kmlInput.accept = '.kml';
   kmlInput.style.display = 'none';
   popup.appendChild(kmlInput);
+  const mapDropOverlay = document.getElementById('map-drop-overlay');
+  let dropCounter = 0;
+
+  function showMapDropOverlay() {
+    if (mapDropOverlay) {
+      mapDropOverlay.style.display = 'flex';
+      mapDropOverlay.style.pointerEvents = 'auto';
+    }
+    map?.dragging.disable();
+  }
+
+  function hideMapDropOverlay() {
+    if (mapDropOverlay) {
+      mapDropOverlay.style.display = 'none';
+      mapDropOverlay.style.pointerEvents = 'none';
+    }
+    map?.dragging.enable();
+  }
+
+  mapDiv.addEventListener('dragenter', (e) => {
+    if (!e.dataTransfer.types?.includes('Files')) return;
+    e.preventDefault();
+    dropCounter++;
+    showMapDropOverlay();
+  });
+
+  mapDiv.addEventListener('dragover', (e) => {
+    if (!e.dataTransfer.types?.includes('Files')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  });
+
+  mapDiv.addEventListener('dragleave', (e) => {
+    if (!e.dataTransfer.types?.includes('Files')) return;
+    e.preventDefault();
+    dropCounter--;
+    if (dropCounter <= 0) hideMapDropOverlay();
+  });
+
+  mapDiv.addEventListener('drop', async (e) => {
+    e.preventDefault();
+    dropCounter = 0;
+    hideMapDropOverlay();
+    const file = Array.from(e.dataTransfer.files).find(f => f.name.endsWith('.kml'));
+    if (!file) return;
+    const text = await file.text();
+    const lines = parseKml(text);
+    clearKmlRoute();
+    lines.forEach(coords => {
+      const line = L.polyline(coords, { color: 'deeppink', weight: 2, opacity: 0.8 }).addTo(map);
+      kmlPolylines.push(line);
+    });
+  });
 
   function createMap(lat, lon) {
     map = L.map(mapDiv).setView([lat, lon], 13);

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -162,7 +162,15 @@
     <div class="popup-drag-bar">
       <button class="popup-close-btn" title="Close">&times;</button>
     </div>
-    <div id="map" style="width:100%;height:calc(100% - 31px);border-radius: 0px 0px 8px 8px;"></div>
+    <div id="map" style="width:100%;height:calc(100% - 31px);border-radius: 0px 0px 8px 8px; position: relative;">
+      <div id="map-drop-overlay">
+        <div style="position: absolute; top: 20px; left: 20px; right: 20px; bottom: 20px; border: 5px dashed rgba(150, 150, 150, 0.8); border-radius: 10px;"></div>
+        <div style="text-align: center; font-family: 'Noto Sans HK', sans-serif; font-size: 24px; color: #333;">
+          <i class="fas fa-cloud-arrow-up" style="font-size:60px; color:#666; margin-bottom:10px;"></i>
+          <div>Drop KML file here</div>
+        </div>
+      </div>
+    </div>
   </div>
   </div>
   <script type="module">

--- a/style.css
+++ b/style.css
@@ -568,6 +568,18 @@ input[type="file"]:hover {
   pointer-events: none;
 }
 
+#map-drop-overlay {
+  position: absolute;
+  top: 0px; left: 0px; right: 0px; bottom: 0px;
+  border: 1px solid;
+  background-color: rgba(255, 255, 255, 0.6);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1001;
+  pointer-events: none;
+}
+
 #loading-overlay {
   position: absolute;
   top: 0px; left: 0px; right: 0px; bottom: 0px;


### PR DESCRIPTION
## Summary
- add `map-drop-overlay` to map popup
- style the overlay similar to the spectrogram drop overlay
- handle drag & drop events on the map to import KML routes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868876ad954832abeb56d4d6cda64be