### PR TITLE
Add drawing tools to map popup

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -54,6 +54,10 @@ export function initMapPopup({
   let kmlPolylines = [];
   let importBtn = null;
   let clearKmlBtn = null;
+  let drawBtn = null;
+  let drawControl = null;
+  let drawnItems = null;
+  let drawControlVisible = false;
   const kmlInput = document.createElement('input');
   kmlInput.type = 'file';
   kmlInput.accept = '.kml';
@@ -168,6 +172,15 @@ export function initMapPopup({
 
     L.control.layers(baseLayers, null, { position: 'topright' }).addTo(map);
 
+    drawnItems = new L.FeatureGroup().addTo(map);
+    drawControl = new L.Control.Draw({
+      position: 'topleft',
+      edit: { featureGroup: drawnItems }
+    });
+    map.on(L.Draw.Event.CREATED, (e) => {
+      drawnItems.addLayer(e.layer);
+    });
+
     const RouteControl = L.Control.extend({
       options: { position: 'topleft' },
       onAdd() {
@@ -215,6 +228,22 @@ export function initMapPopup({
       }
     });
     map.addControl(new ClearKmlControl());
+
+    const DrawToggleControl = L.Control.extend({
+      options: { position: 'topleft' },
+      onAdd() {
+        const container = L.DomUtil.create('div', 'leaflet-bar leaflet-draw-toggle-control');
+        const link = L.DomUtil.create('a', '', container);
+        link.href = '#';
+        link.title = 'Draw';
+        link.innerHTML = '<i class="fa-solid fa-pen-to-square"></i>';
+        drawBtn = link;
+        L.DomEvent.on(link, 'click', L.DomEvent.stop)
+          .on(link, 'click', toggleDrawControl);
+        return container;
+      }
+    });
+    map.addControl(new DrawToggleControl());
   }
 
   function refreshMarkers() {
@@ -359,6 +388,19 @@ export function initMapPopup({
     } else {
       drawRoute();
       routeBtn?.classList.add('active');
+    }
+  }
+
+  function toggleDrawControl() {
+    if (!drawControl) return;
+    if (drawControlVisible) {
+      map.removeControl(drawControl);
+      drawBtn?.classList.remove('active');
+      drawControlVisible = false;
+    } else {
+      drawControl.addTo(map);
+      drawBtn?.classList.add('active');
+      drawControlVisible = true;
     }
   }
 

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -8,8 +8,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+HK&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.css" />
   <link rel="icon" href="./favicon.ico" sizes="any" type="image/x-icon" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.draw/1.0.4/leaflet.draw.js"></script>
 </head>
 <body>
 

--- a/style.css
+++ b/style.css
@@ -876,7 +876,8 @@ input.tag-button.editing {
 /* Route button style */
 .leaflet-route-control a,
 .leaflet-import-kml-control a,
-.leaflet-clear-kml-control a {
+.leaflet-clear-kml-control a,
+.leaflet-draw-toggle-control a {
   width: 26px;
   height: 26px;
   line-height: 26px;
@@ -889,12 +890,25 @@ input.tag-button.editing {
 }
 
 .leaflet-import-kml-control,
-.leaflet-clear-kml-control {
+.leaflet-clear-kml-control,
+.leaflet-draw-toggle-control {
   margin-top: 1px !important;
 }
 
 .leaflet-route-control a i,
 .leaflet-import-kml-control a i,
-.leaflet-clear-kml-control a i {
+.leaflet-clear-kml-control a i,
+.leaflet-draw-toggle-control a i {
   color: #363636;
+}
+
+/* Draw toolbar layout */
+.leaflet-top.leaflet-left .leaflet-draw {
+  left: 50%;
+  transform: translateX(-50%);
+  top: 10px;
+}
+.leaflet-draw-toolbar {
+  display: flex;
+  flex-direction: row;
 }


### PR DESCRIPTION
## Summary
- integrate leaflet-draw library
- add drawing toggle button below trash icon
- display horizontal draw toolbar at top center of map

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68688e2b2f04832aa8f23c1a0591f812