### PR TITLE
Fix draw toolbar alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -903,6 +903,9 @@ input.tag-button.editing {
 }
 
 /* Draw toolbar layout */
+.map-popup .leaflet-top.leaflet-left {
+  width: 100%;
+}
 .leaflet-top.leaflet-left .leaflet-draw {
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
## Summary
- ensure `.leaflet-top.leaflet-left` spans full width of the map so the draw toolbar centers properly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68689263a9f4832a9ffb025e5c095cfc