### PR TITLE
Add coordinate scale overlay

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -58,6 +58,9 @@ export function initMapPopup({
   let drawControl = null;
   let drawnItems = null;
   let drawControlVisible = false;
+  const coordScaleWrapper = mapDiv.querySelector('.coord-scale-wrapper');
+  const coordDisplay = mapDiv.querySelector('#coord-display');
+  let scaleControl = null;
   const kmlInput = document.createElement('input');
   kmlInput.type = 'file';
   kmlInput.accept = '.kml';
@@ -124,6 +127,20 @@ export function initMapPopup({
 
   function createMap(lat, lon) {
     map = L.map(mapDiv).setView([lat, lon], 13);
+    scaleControl = L.control.scale({ position: 'bottomleft' }).addTo(map);
+    if (coordScaleWrapper) {
+      const scaleEl = scaleControl.getContainer();
+      scaleEl.style.position = 'static';
+      coordScaleWrapper.appendChild(scaleEl);
+    }
+    function updateCoords(latlng) {
+      if (!coordDisplay) return;
+      const { lat, lng } = latlng;
+      coordDisplay.textContent = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+    }
+    map.on('mousemove', (e) => updateCoords(e.latlng));
+    map.on('move', () => updateCoords(map.getCenter()));
+    updateCoords(map.getCenter());
 
     const osmAttr = { attribution: '&copy; OpenStreetMap contributors' };
     const esriAttr = { attribution: '&copy; Esri' };

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -172,6 +172,7 @@
           <div>Drop KML file here</div>
         </div>
       </div>
+      <div class="coord-scale-wrapper"><span id="coord-display"></span></div>
     </div>
   </div>
   </div>

--- a/style.css
+++ b/style.css
@@ -824,6 +824,22 @@ input.tag-button.editing {
   color: #c00;
 }
 
+.coord-scale-wrapper {
+  position: absolute;
+  bottom: 6px;
+  left: 6px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  pointer-events: none;
+  z-index: 500;
+}
+.coord-scale-wrapper .leaflet-control-scale {
+  margin: 0;
+  background: transparent;
+}
+
 .map-marker-other i{
   font-size: 28px;
   line-height: 28px;


### PR DESCRIPTION
## Summary
- display coordinate and scale information inside the map popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68689d465e50832aaab962da79002c84