### PR TITLE
Add default tags and tooltips for demo file

### DIFF
--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -88,6 +88,7 @@ export function initSidebar({ onFileSelected } = {}) {
         d.className = 'fa-solid fa-trash';
         d.style.color = 'gray';
         d.style.marginLeft = '4px';
+        d.title = 'Mark as Trash (Delete)';
         flags.appendChild(d);
       }
       if (state.star) {
@@ -95,6 +96,7 @@ export function initSidebar({ onFileSelected } = {}) {
         s.className = 'fa-solid fa-star';
         s.style.color = '#FFD700';
         s.style.marginLeft = '4px';
+        s.title = 'Mark as Star ( * button)';
         flags.appendChild(s);
       }
       if (state.question) {
@@ -102,6 +104,7 @@ export function initSidebar({ onFileSelected } = {}) {
         q.className = 'fa-solid fa-question';
         q.style.color = 'red';
         q.style.marginLeft = '4px';
+        q.title = 'Mark as Question ( ? button)';
         flags.appendChild(q);
       }
 

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -304,6 +304,9 @@
         const blob = await resp.blob();
         const demoFile = new File([blob], 'demo_recording.wav', { type: 'audio/wav' });
         setFileList([demoFile], -1);
+        toggleFileIcon(0, 'trash');
+        toggleFileIcon(0, 'star');
+        toggleFileIcon(0, 'question');
         sidebarControl.refresh(demoFile.name);
       } catch (err) {
         console.error('Failed to preload demo file', err);


### PR DESCRIPTION
## Summary
- tag `demo_recording.wav` with trash, star and question flags on load
- show tooltip titles on sidebar tag icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ae5b24a8832abc950e9cfa33a204