### PR TITLE
Add notice for wav files without coordinates

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -60,6 +60,7 @@ export function initMapPopup({
   let drawControlVisible = false;
   const coordScaleWrapper = mapDiv.querySelector('.coord-scale-wrapper');
   const coordDisplay = mapDiv.querySelector('#coord-display');
+  const noCoordMsg = mapDiv.querySelector('#no-coord-message');
   let scaleControl = null;
   const kmlInput = document.createElement('input');
   kmlInput.type = 'file';
@@ -83,6 +84,14 @@ export function initMapPopup({
       mapDropOverlay.style.pointerEvents = 'none';
     }
     map?.dragging.enable();
+  }
+
+  function showNoCoordMessage() {
+    if (noCoordMsg) noCoordMsg.style.display = 'flex';
+  }
+
+  function hideNoCoordMessage() {
+    if (noCoordMsg) noCoordMsg.style.display = 'none';
   }
 
   mapDiv.addEventListener('dragenter', (e) => {
@@ -451,12 +460,18 @@ export function initMapPopup({
     if (idx < 0) {
       refreshMarkers();
       showDeviceLocation();
+      hideNoCoordMessage();
       return;
     }
     const meta = getFileMetadata(idx);
     const lat = parseFloat(meta.latitude);
     const lon = parseFloat(meta.longitude);
-    if (isNaN(lat) || isNaN(lon)) return;
+    if (isNaN(lat) || isNaN(lon)) {
+      refreshMarkers();
+      showNoCoordMessage();
+      return;
+    }
+    hideNoCoordMessage();
 
     if (!map) {
       createMap(lat, lon);

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -174,6 +174,7 @@
         </div>
       </div>
       <div class="coord-scale-wrapper"><span id="coord-display"></span></div>
+      <div id="no-coord-message" class="coord-scale-wrapper" style="top:0; left:50%; transform:translateX(-50%); margin-top:10px; bottom:auto; display:none;">This wav file without coordinates</div>
     </div>
   </div>
   <div id="trashProgramPopup" class="map-popup" style="display:none;">


### PR DESCRIPTION
## Summary
- show a message box when the loaded wav file lacks coordinates
- hide this message when coordinates are available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68693d1dec74832a84d74fb767f599d5