### PR TITLE
Enable manual overlap value input

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -81,7 +81,7 @@
           <button id="fftSizeInput" class="dropdown-button" title="FFT Size">1024</button>
         </label>
         <label class="slider-label">Overlap
-          <button id="overlapInput" class="dropdown-button" title="Overlap Size">Auto</button>
+          <input type="number" id="overlapInput" title="Overlap Size (1-99)" placeholder="Auto" min="1" max="99" step="1" style="width: 40px; padding-right:0px; text-align:center">
         </label>
         <div class="toolbar-divider"></div>
         <label class="slider-label">F.Range
@@ -581,20 +581,24 @@ To proceed:
     ], { onChange: (item) => handleFftSize(item.value) });
     fftSizeDropdown.select(1);
 
-    const overlapDropdown = initDropdown('overlapInput', [
-      { label: 'Auto', value: 'auto' },
-      { label: '10%', value: 10 },
-      { label: '20%', value: 20 },
-      { label: '30%', value: 30 },
-      { label: '40%', value: 40 },
-      { label: '50%', value: 50 },
-      { label: '60%', value: 60 },
-      { label: '70%', value: 70 },
-      { label: '80%', value: 80 },   
-      { label: '90%', value: 90 },
-      { label: '98%', value: 98 },
-    ], { onChange: (item) => { currentOverlap = item.value; handleOverlapChange(); } });
-    overlapDropdown.select(0);
+    const overlapInput = document.getElementById('overlapInput');
+    overlapInput.value = '';
+    overlapInput.addEventListener('change', () => {
+      const val = overlapInput.value.trim();
+      if (val === '') {
+        currentOverlap = 'auto';
+      } else {
+        const num = parseInt(val, 10);
+        if (!isNaN(num) && num >= 1 && num <= 99) {
+          currentOverlap = num;
+        } else {
+          alert('Overlap must be between 1 and 99.');
+          overlapInput.value = '';
+          currentOverlap = 'auto';
+        }
+      }
+      handleOverlapChange();
+    });
     
     function updateSpectrogramSettingsText() {
       const settingBox = document.getElementById('spectrogram-settings');


### PR DESCRIPTION
## Summary
- replace overlap dropdown with number input
- support selecting Auto or entering a value from 1-99

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869c66d9f08832a9f73a39064adf4d7