### PR TITLE
Add upload progress overlay

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -17,6 +17,9 @@ export function initDragDropLoader({
 }) {
   const dropArea = document.getElementById(targetElementId);
   const overlay = document.getElementById('drop-overlay');
+  const uploadOverlay = document.getElementById('upload-overlay');
+  const uploadProgressBar = document.getElementById('upload-progress-bar');
+  const uploadProgressText = document.getElementById('upload-progress-text');
   const fileNameElem = document.getElementById('fileNameText');
   const guanoOutput = document.getElementById('guano-output');
   const spectrogramSettings = document.getElementById('spectrogram-settings');  
@@ -30,6 +33,27 @@ export function initDragDropLoader({
   function hideOverlay() {
     overlay.style.display = 'none';
     document.dispatchEvent(new Event('drop-overlay-hide'));
+  }
+
+  function showUploadOverlay(total) {
+    if (!uploadOverlay) return;
+    if (uploadProgressBar) uploadProgressBar.style.width = '0%';
+    if (uploadProgressText) uploadProgressText.textContent = `0/${total}`;
+    uploadOverlay.style.display = 'flex';
+  }
+
+  function updateUploadOverlay(count, total) {
+    if (uploadProgressBar) {
+      const pct = total > 0 ? (count / total) * 100 : 0;
+      uploadProgressBar.style.width = `${pct}%`;
+    }
+    if (uploadProgressText) {
+      uploadProgressText.textContent = `${count}/${total}`;
+    }
+  }
+
+  function hideUploadOverlay() {
+    if (uploadOverlay) uploadOverlay.style.display = 'none';
   }
 
   async function loadFile(file) {
@@ -92,6 +116,8 @@ export function initDragDropLoader({
       return;
     }
 
+    showUploadOverlay(validFiles.length);
+
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
     }
@@ -108,7 +134,9 @@ export function initDragDropLoader({
       } catch (err) {
         setFileMetadata(startIdx + i, { date: '', time: '', latitude: '', longitude: '' });
       }
+      updateUploadOverlay(i + 1, sortedList.length);
     }
+    hideUploadOverlay();
     await loadFile(sortedList[0]);
   }
 

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -43,7 +43,31 @@ export function initFileLoader({
   const nextBtn = document.getElementById('nextBtn');
   const fileNameElem = document.getElementById('fileNameText');
   const guanoOutput = document.getElementById('guano-output');
-  const spectrogramSettings = document.getElementById('spectrogram-settings');  
+  const spectrogramSettings = document.getElementById('spectrogram-settings');
+  const uploadOverlay = document.getElementById('upload-overlay');
+  const uploadProgressBar = document.getElementById('upload-progress-bar');
+  const uploadProgressText = document.getElementById('upload-progress-text');
+
+  function showUploadOverlay(total) {
+    if (!uploadOverlay) return;
+    if (uploadProgressBar) uploadProgressBar.style.width = '0%';
+    if (uploadProgressText) uploadProgressText.textContent = `0/${total}`;
+    uploadOverlay.style.display = 'flex';
+  }
+
+  function updateUploadOverlay(count, total) {
+    if (uploadProgressBar) {
+      const pct = total > 0 ? (count / total) * 100 : 0;
+      uploadProgressBar.style.width = `${pct}%`;
+    }
+    if (uploadProgressText) {
+      uploadProgressText.textContent = `${count}/${total}`;
+    }
+  }
+
+  function hideUploadOverlay() {
+    if (uploadOverlay) uploadOverlay.style.display = 'none';
+  }
 
   async function loadFile(file) {
     if (!file) return;
@@ -104,11 +128,12 @@ export function initFileLoader({
     const selectedFile = files[0];
     if (!selectedFile) return;
 
+    const sameDirFiles = files.filter(f => f.name.endsWith('.wav'));
+    showUploadOverlay(sameDirFiles.length);
+
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
     }
-
-    const sameDirFiles = files.filter(f => f.name.endsWith('.wav'));
 
     const sortedList = sameDirFiles.sort((a, b) => a.name.localeCompare(b.name));
     const index = sortedList.findIndex(f => f.name === selectedFile.name);
@@ -124,7 +149,9 @@ export function initFileLoader({
       } catch (err) {
         setFileMetadata(startIdx + i, { date: '', time: '', latitude: '', longitude: '' });
       }
+      updateUploadOverlay(i + 1, sortedList.length);
     }
+    hideUploadOverlay();
     await loadFile(selectedFile);
   });
 

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -138,6 +138,13 @@
             <div id="loading-overlay" class="loading-overlay">
               <div class="spinner"></div>
             </div>
+            <div id="upload-overlay" class="upload-overlay">
+              <div class="spinner"></div>
+              <div class="progress-container">
+                <div class="progress-bar" id="upload-progress-bar"></div>
+              </div>
+              <div id="upload-progress-text" class="progress-text">0/0</div>
+            </div>
             <div id="viewer-container">
             <div id="spectrogram-only" style="height: 800px;"></div>
             <canvas id="freq-grid"></canvas>

--- a/style.css
+++ b/style.css
@@ -601,6 +601,42 @@ input[type="file"]:hover {
   animation: spin 1s linear infinite;
 }
 
+#upload-overlay {
+  position: absolute;
+  top: 0px; left: 0px; right: 0px; bottom: 0px;
+  border: 1px solid;
+  background-color: rgba(255, 255, 255, 0.6);
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 998;
+  pointer-events: none;
+}
+
+#upload-overlay .progress-container {
+  width: 60%;
+  height: 10px;
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+  margin-top: 10px;
+  overflow: hidden;
+}
+
+#upload-overlay .progress-bar {
+  height: 100%;
+  width: 0%;
+  background-color: #333;
+  border-radius: 5px;
+}
+
+#upload-overlay .progress-text {
+  margin-top: 6px;
+  font-size: 14px;
+  color: #333;
+  font-family: 'Noto Sans HK', sans-serif;
+}
+
 @keyframes spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }


### PR DESCRIPTION
## Summary
- add overlay showing progress of uploaded files
- display progress bar and processed count while loading multiple WAVs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869cb78dd30832a8bd42c095e16460b