### PR TITLE
Refine upload overlay layout

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -139,6 +139,7 @@
               <div class="spinner"></div>
             </div>
             <div id="upload-overlay" class="upload-overlay">
+              <div class="spinner"></div>
               <div class="progress-container">
                 <div class="progress-bar" id="upload-progress-bar"></div>
               </div>
@@ -267,6 +268,7 @@ To proceed:
     });
     const overlay = document.getElementById('drop-overlay');
     const loadingOverlay = document.getElementById('loading-overlay');
+    const uploadOverlay = document.getElementById('upload-overlay');
 
     function showDropOverlay() {
       overlay.style.display = 'flex';
@@ -304,12 +306,16 @@ To proceed:
         sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
-        loadingOverlay.style.display = 'flex';
+        if (uploadOverlay.style.display !== 'flex') {
+          loadingOverlay.style.display = 'flex';
+        }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
       },
       onAfterLoad: () => {
-        loadingOverlay.style.display = 'none';
+        if (uploadOverlay.style.display !== 'flex') {
+          loadingOverlay.style.display = 'none';
+        }
         freqHoverControl?.refreshHover();
         updateSpectrogramSettingsText();
       },
@@ -518,12 +524,16 @@ To proceed:
         sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
-        loadingOverlay.style.display = 'flex';
+        if (uploadOverlay.style.display !== 'flex') {
+          loadingOverlay.style.display = 'flex';
+        }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
       },
       onAfterLoad: () => {
-        loadingOverlay.style.display = 'none';
+        if (uploadOverlay.style.display !== 'flex') {
+          loadingOverlay.style.display = 'none';
+        }
         freqHoverControl?.refreshHover();
         updateSpectrogramSettingsText();
       },

--- a/style.css
+++ b/style.css
@@ -614,10 +614,19 @@ input[type="file"]:hover {
   pointer-events: none;
 }
 
+#upload-overlay .spinner {
+  border: 4px solid rgba(0, 0, 0, 0.3);
+  border-top: 4px solid #333;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
 #upload-overlay .progress-container {
   width: 60%;
   height: 10px;
-  background-color: rgba(0, 0, 0, 0.2);
+  background-color: #ccc;
   border-radius: 5px;
   margin-top: 10px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add spinner to the upload overlay
- keep loader spinner hidden during uploads
- make progress bar background solid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869cfa0ca1c832a9371002a4edbd652