### PR TITLE
Use messageBox for invalid file alert

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -3,6 +3,7 @@
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { getWavSampleRate } from './fileLoader.js';
 import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
+import { showMessageBox } from './messageBox.js';
 
 export function initDragDropLoader({
   targetElementId,
@@ -112,7 +113,7 @@ export function initDragDropLoader({
   async function handleFiles(files) {
     const validFiles = Array.from(files).filter(file => file.type === 'audio/wav' || file.name.endsWith('.wav'));
     if (validFiles.length === 0) {
-      alert('Only .wav files are supported.');
+      showMessageBox({ message: 'Only .wav files are supported.' });
       return;
     }
 


### PR DESCRIPTION
## Summary
- show messageBox when dropped files are not .wav

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869d90ef260832a861997d5ed09b598