### PR TITLE
Add overlap size warning

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -208,6 +208,7 @@
     import { initSidebar } from './modules/sidebar.js';
     import { initTagControl } from './modules/tagControl.js';
     import { initDropdown } from './modules/dropdown.js';
+    import { showMessageBox } from './modules/messageBox.js';
     import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
     const spectrogramHeight = 800;
@@ -232,6 +233,7 @@
     let selectedSampleRate = 'auto';
     let currentFftSize = 1024;
     let currentOverlap = 'auto';
+    let overlapWarningShown = false;
     let freqHoverControl = null;
     const getDuration = () => duration;
 
@@ -591,6 +593,12 @@
         const num = parseInt(val, 10);
         if (!isNaN(num) && num >= 1 && num <= 99) {
           currentOverlap = num;
+          if (num >= 80 && !overlapWarningShown) {
+            showMessageBox({
+              message: `Reminder:\nUsing an overlap size above 80% can significantly increase rendering time. If the .wav file is longer than 8 seconds or high-level zoom-in is enabled, large overlap sizes are not recommended.`
+            });
+            overlapWarningShown = true;
+          }
         } else {
           alert('Overlap must be between 1 and 99.');
           overlapInput.value = '';


### PR DESCRIPTION
## Summary
- warn once when overlap size is 80 or more

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6869dc5da5f4832a8be195c8716cff9e