### PR TITLE
Add title support in message boxes

### DIFF
--- a/modules/messageBox.js
+++ b/modules/messageBox.js
@@ -2,6 +2,7 @@
 
 export function showMessageBox({
   message = '',
+  title = '',
   confirmText = 'OK',
   cancelText = null,
   onConfirm,
@@ -20,6 +21,12 @@ export function showMessageBox({
 
   const dragBar = document.createElement('div');
   dragBar.className = 'popup-drag-bar';
+  if (title) {
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'popup-title';
+    titleSpan.textContent = title;
+    dragBar.appendChild(titleSpan);
+  }
   const closeBtn = document.createElement('button');
   closeBtn.className = 'popup-close-btn';
   closeBtn.title = 'Close';

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -595,7 +595,8 @@
           currentOverlap = num;
           if (num >= 80 && !overlapWarningShown) {
             showMessageBox({
-              message: `Reminder:\nUsing an overlap size above 80% can significantly increase rendering time. If the .wav file is longer than 8 seconds or high-level zoom-in is enabled, large overlap sizes are not recommended.`
+              title: 'Reminder',
+              message: `Using an overlap size above 80% can significantly increase rendering time. If the .wav file is longer than 8 seconds or high-level zoom-in is enabled, large overlap sizes are not recommended.`
             });
             overlapWarningShown = true;
           }

--- a/style.css
+++ b/style.css
@@ -854,6 +854,12 @@ input.tag-button.editing {
   user-select: none;
 }
 
+.popup-title {
+  margin-left: 10px;
+  font-weight: bold;
+  font-size: 14px;
+}
+
 .popup-close-btn {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- allow setting a title in `showMessageBox`
- style `.popup-title` and display it in the drag bar
- show "Reminder" title for the overlap warning popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869df041e18832a957cc793af98a90e