### PR TITLE
Add text drawing support

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -55,6 +55,8 @@ export function initMapPopup({
   let importBtn = null;
   let clearKmlBtn = null;
   let drawBtn = null;
+  let textBtn = null;
+  let textMode = false;
   let drawControl = null;
   let drawnItems = null;
   let drawControlVisible = false;
@@ -205,7 +207,8 @@ export function initMapPopup({
     drawnItems = new L.FeatureGroup().addTo(map);
     drawControl = new L.Control.Draw({
       position: 'topleft',
-      edit: { featureGroup: drawnItems }
+      edit: { featureGroup: drawnItems },
+      draw: { circlemarker: false }
     });
     map.on(L.Draw.Event.CREATED, (e) => {
       drawnItems.addLayer(e.layer);
@@ -274,6 +277,22 @@ export function initMapPopup({
       }
     });
     map.addControl(new DrawToggleControl());
+
+    const TextControl = L.Control.extend({
+      options: { position: 'topleft' },
+      onAdd() {
+        const container = L.DomUtil.create('div', 'leaflet-bar leaflet-draw-text-control');
+        const link = L.DomUtil.create('a', '', container);
+        link.href = '#';
+        link.title = 'Text';
+        link.innerHTML = '<i class="fa-solid fa-font"></i>';
+        textBtn = link;
+        L.DomEvent.on(link, 'click', L.DomEvent.stop)
+          .on(link, 'click', toggleTextMode);
+        return container;
+      }
+    });
+    map.addControl(new TextControl());
   }
 
   function refreshMarkers() {
@@ -434,6 +453,40 @@ export function initMapPopup({
     }
   }
 
+  function exitTextMode() {
+    textMode = false;
+    map?.off('click', handleTextClick);
+    textBtn?.classList.remove('active');
+    map?.dragging.enable();
+    if (map) map.getContainer().style.cursor = '';
+  }
+
+  function handleTextClick(e) {
+    const txt = prompt('Enter text:');
+    if (txt && txt.trim()) {
+      const icon = L.divIcon({
+        html: `<span class="map-text-marker">${txt}</span>`,
+        className: '',
+        iconSize: [0, 0]
+      });
+      const marker = L.marker(e.latlng, { icon, draggable: true });
+      drawnItems.addLayer(marker);
+    }
+    exitTextMode();
+  }
+
+  function toggleTextMode() {
+    if (textMode) {
+      exitTextMode();
+    } else {
+      textMode = true;
+      map?.on('click', handleTextClick);
+      textBtn?.classList.add('active');
+      map?.dragging.disable();
+      if (map) map.getContainer().style.cursor = 'crosshair';
+    }
+  }
+
   function showDeviceLocation() {
     if (!navigator.geolocation) return;
     navigator.geolocation.getCurrentPosition((pos) => {
@@ -483,6 +536,7 @@ export function initMapPopup({
 
   function togglePopup() {
     if (popup.style.display === 'block') {
+      exitTextMode();
       popup.style.display = 'none';
       document.body.classList.remove('map-open');
       clearRoute();

--- a/style.css
+++ b/style.css
@@ -945,11 +945,20 @@ input.tag-button.editing {
   white-space: nowrap;
 }
 
+.map-text-marker {
+  font-size: 16px;
+  color: #000;
+  text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
 /* Route button style */
 .leaflet-route-control a,
 .leaflet-import-kml-control a,
 .leaflet-clear-kml-control a,
-.leaflet-draw-toggle-control a {
+.leaflet-draw-toggle-control a,
+.leaflet-draw-text-control a {
   width: 26px;
   height: 26px;
   line-height: 26px;
@@ -960,16 +969,22 @@ input.tag-button.editing {
   background-color: #e6e6e6;
 }
 
+.leaflet-draw-text-control a.active {
+  background-color: #e6e6e6;
+}
+
 .leaflet-import-kml-control,
 .leaflet-clear-kml-control,
-.leaflet-draw-toggle-control {
+.leaflet-draw-toggle-control,
+.leaflet-draw-text-control {
   margin-top: 1px !important;
 }
 
 .leaflet-route-control a i,
 .leaflet-import-kml-control a i,
 .leaflet-clear-kml-control a i,
-.leaflet-draw-toggle-control a i {
+.leaflet-draw-toggle-control a i,
+.leaflet-draw-text-control a i {
   color: #363636;
 }
 


### PR DESCRIPTION
## Summary
- disable circle markers in Leaflet draw control
- add text drawing mode and control
- style text markers and new draw button

## Testing
- `node --version`
- `node --check modules/mapPopup.js`
- `node --check style.css` *(fails: Unknown file extension)*

------
https://chatgpt.com/codex/tasks/task_e_686a07de0a14832aab4d5d2dc0cc22ea