### PR TITLE
Add Text mode for Leaflet map

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -55,6 +55,10 @@ export function initMapPopup({
   let importBtn = null;
   let clearKmlBtn = null;
   let drawBtn = null;
+  let textBtn = null;
+  let textMode = false;
+  let textMarkers = [];
+  let activeTextInput = null;
   let drawControl = null;
   let drawnItems = null;
   let drawControlVisible = false;
@@ -260,6 +264,22 @@ export function initMapPopup({
     });
     map.addControl(new ClearKmlControl());
 
+    const TextToggleControl = L.Control.extend({
+      options: { position: 'topleft' },
+      onAdd() {
+        const container = L.DomUtil.create('div', 'leaflet-bar leaflet-text-toggle-control');
+        const link = L.DomUtil.create('a', '', container);
+        link.href = '#';
+        link.title = 'Text';
+        link.innerHTML = '<i class="fa-solid fa-font"></i>';
+        textBtn = link;
+        L.DomEvent.on(link, 'click', L.DomEvent.stop)
+          .on(link, 'click', toggleTextMode);
+        return container;
+      }
+    });
+    map.addControl(new TextToggleControl());
+
     const DrawToggleControl = L.Control.extend({
       options: { position: 'topleft' },
       onAdd() {
@@ -435,6 +455,101 @@ export function initMapPopup({
     }
   }
 
+  function escapeHtml(str) {
+    return str.replace(/[&<>"]/g, (c) => ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;'
+    })[c]);
+  }
+
+  function createTextIcon(text) {
+    return L.divIcon({
+      className: 'map-text-icon',
+      html: `<span class="map-text-label">${escapeHtml(text)}</span>`
+    });
+  }
+
+  function editTextMarker(marker) {
+    if (!map || activeTextInput) return;
+    const latlng = marker.getLatLng();
+    const point = map.latLngToContainerPoint(latlng);
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.value = marker.text || '';
+    input.className = 'map-text-input';
+    input.style.left = `${point.x}px`;
+    input.style.top = `${point.y}px`;
+    map.getContainer().appendChild(input);
+    activeTextInput = input;
+    map.dragging.disable();
+    input.focus();
+    const finish = () => {
+      if (!activeTextInput) return;
+      const val = input.value.trim();
+      map.getContainer().removeChild(input);
+      activeTextInput = null;
+      map.dragging.enable();
+      if (val) {
+        marker.text = val;
+        marker.setIcon(createTextIcon(val));
+      } else {
+        map.removeLayer(marker);
+        textMarkers = textMarkers.filter(m => m !== marker);
+      }
+    };
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        finish();
+      }
+    });
+    input.addEventListener('blur', finish);
+  }
+
+  function createTextMarker(latlng, text) {
+    const marker = L.marker(latlng, { icon: createTextIcon(text), draggable: textMode });
+    marker.text = text;
+    marker.on('dblclick', () => { if (textMode) editTextMarker(marker); });
+    marker.on('contextmenu', () => {
+      if (textMode && !activeTextInput) {
+        map.removeLayer(marker);
+        textMarkers = textMarkers.filter(m => m !== marker);
+      }
+    });
+    return marker;
+  }
+
+  function updateTextMarkersDraggable() {
+    textMarkers.forEach(m => {
+      if (textMode) m.dragging.enable();
+      else m.dragging.disable();
+    });
+  }
+
+  function onMapTextClick(e) {
+    if (activeTextInput) return;
+    const marker = createTextMarker(e.latlng, '');
+    marker.addTo(map);
+    textMarkers.push(marker);
+    editTextMarker(marker);
+  }
+
+  function toggleTextMode() {
+    textMode = !textMode;
+    textBtn?.classList.toggle('active', textMode);
+    if (textMode) {
+      map.on('click', onMapTextClick);
+    } else {
+      map.off('click', onMapTextClick);
+      if (activeTextInput) {
+        activeTextInput.blur();
+      }
+    }
+    updateTextMarkersDraggable();
+  }
+
   function showDeviceLocation() {
     if (!navigator.geolocation) return;
     navigator.geolocation.getCurrentPosition((pos) => {
@@ -488,6 +603,7 @@ export function initMapPopup({
       document.body.classList.remove('map-open');
       clearRoute();
       clearKmlRoute();
+      if (textMode) toggleTextMode();
     } else {
       popup.style.display = 'block';
       document.body.classList.add('map-open');

--- a/style.css
+++ b/style.css
@@ -979,3 +979,51 @@ input.tag-button.editing {
     border-radius: 5px !important;
     margin: -5px !important;
 }
+
+/* Text button */
+.leaflet-text-toggle-control a {
+  width: 26px;
+  height: 26px;
+  line-height: 26px;
+  text-align: center;
+}
+
+.leaflet-text-toggle-control {
+  margin-top: 1px !important;
+}
+
+.leaflet-text-toggle-control a.active {
+  background-color: #e6e6e6;
+}
+
+.leaflet-text-toggle-control a i {
+  color: #363636;
+}
+
+/* Text label style */
+.map-text-icon {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+  width: auto !important;
+  height: auto !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.map-text-label {
+  font-size: 16px;
+  color: #000;
+  white-space: pre;
+  text-shadow: -1px -1px 0 #ffffff, 1px -1px 0 #ffffff, -1px 1px 0 #ffffff, 1px 1px 0 #ffffff;
+  pointer-events: auto;
+}
+
+.map-text-input {
+  position: absolute;
+  font-size: 16px;
+  padding: 2px 4px;
+  border: 1px solid #000000;
+  background: #ffffff;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add a new Text toggle tool for the map
- implement text markers with editing and dragging
- disable editing when leaving text mode or closing map
- style the Text button and text markers

## Testing
- `node -e "require('./modules/mapPopup.js')"`

------
https://chatgpt.com/codex/tasks/task_e_686a0ccff978832a8f2a8bda90e892a9