### PR TITLE
Fix text marker editing behavior

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -512,6 +512,12 @@ export function initMapPopup({
     const marker = L.marker(latlng, { icon: createTextIcon(text), draggable: textMode });
     marker.text = text;
     marker.on('dblclick', () => { if (textMode) editTextMarker(marker); });
+    marker.on('click', (e) => {
+      if (textMode && !activeTextInput) {
+        e.originalEvent.stopPropagation();
+        editTextMarker(marker);
+      }
+    });
     marker.on('contextmenu', () => {
       if (textMode && !activeTextInput) {
         map.removeLayer(marker);


### PR DESCRIPTION
## Summary
- improve text editing workflow on the map

## Testing
- `node -c modules/mapPopup.js`
- `for f in modules/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_686a0f854d0c832ab0a02892c23a19c8