### PR TITLE
Avoid text box closing when clicked

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -508,7 +508,12 @@ export function initMapPopup({
         finish();
       }
     });
-    input.addEventListener('blur', finish);
+    input.addEventListener('pointerdown', (e) => e.stopPropagation());
+    input.addEventListener('blur', () => {
+      setTimeout(() => {
+        if (document.activeElement !== input) finish();
+      });
+    });
   }
 
   function createTextMarker(latlng, text) {


### PR DESCRIPTION
## Summary
- stop event propagation when text box is clicked
- ignore blur if text box regains focus

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a143de920832a8c84eb0094dd4d74