### PR TITLE
Handle newline editing in text mode

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -478,17 +478,23 @@ export function initMapPopup({
     if (!map || activeTextInput) return;
     const latlng = marker.getLatLng();
     const point = map.latLngToContainerPoint(latlng);
-    const input = document.createElement('textarea');
-    input.value = marker.text || '';
-    input.className = 'map-text-input';
-    input.rows = 1;
-    input.style.left = `${point.x}px`;
-    input.style.top = `${point.y}px`;
-    map.getContainer().appendChild(input);
-    activeTextInput = input;
-    map.dragging.disable();
-    input.focus();
-    const finish = () => {
+  const input = document.createElement('textarea');
+  input.value = marker.text || '';
+  input.className = 'map-text-input';
+  input.rows = 1;
+  input.style.left = `${point.x}px`;
+  input.style.top = `${point.y}px`;
+  map.getContainer().appendChild(input);
+  activeTextInput = input;
+  map.dragging.disable();
+  input.focus();
+  const adjustHeight = () => {
+    input.style.height = 'auto';
+    input.style.height = `${input.scrollHeight}px`;
+  };
+  adjustHeight();
+  input.addEventListener('input', adjustHeight);
+  const finish = () => {
       if (!activeTextInput) return;
       const val = input.value.trim();
       map.getContainer().removeChild(input);

--- a/style.css
+++ b/style.css
@@ -1028,4 +1028,6 @@ input.tag-button.editing {
   border-radius: 5px;
   background: rgba(255, 255, 255, 0.8);
   z-index: 1000;
+  overflow: hidden;
+  resize: none;
 }


### PR DESCRIPTION
## Summary
- auto-adjust map text editing boxes when typing
- prevent overflowing/resizing via CSS

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_686a18cdbb44832aa41582f3b4e3cdb5