### PR TITLE
Implement cropped expand-selection mode

### DIFF
--- a/modules/cropAudio.js
+++ b/modules/cropAudio.js
@@ -1,0 +1,62 @@
+export async function cropWavBlob(file, startTime, endTime) {
+  if (!file) return null;
+  const arrayBuffer = await file.arrayBuffer();
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer.slice(0));
+  const sampleRate = audioBuffer.sampleRate;
+  const startSample = Math.floor(startTime * sampleRate);
+  const endSample = Math.floor(endTime * sampleRate);
+  const length = Math.max(0, endSample - startSample);
+  const numChannels = audioBuffer.numberOfChannels;
+  const newBuffer = audioCtx.createBuffer(numChannels, length, sampleRate);
+  for (let ch = 0; ch < numChannels; ch++) {
+    const channelData = audioBuffer.getChannelData(ch).slice(startSample, endSample);
+    newBuffer.getChannelData(ch).set(channelData);
+  }
+  return audioBufferToWav(newBuffer);
+}
+
+function audioBufferToWav(buffer) {
+  const numChannels = buffer.numberOfChannels;
+  const sampleRate = buffer.sampleRate;
+  const format = 1;
+  const bitDepth = 16;
+  const samples = buffer.length;
+  const blockAlign = numChannels * bitDepth / 8;
+  const byteRate = sampleRate * blockAlign;
+  const dataLength = samples * blockAlign;
+  const bufferLength = 44 + dataLength;
+  const arrayBuffer = new ArrayBuffer(bufferLength);
+  const view = new DataView(arrayBuffer);
+  let offset = 0;
+  function writeString(str) {
+    for (let i = 0; i < str.length; i++) {
+      view.setUint8(offset++, str.charCodeAt(i));
+    }
+  }
+  writeString('RIFF');
+  view.setUint32(offset, 36 + dataLength, true); offset += 4;
+  writeString('WAVE');
+  writeString('fmt ');
+  view.setUint32(offset, 16, true); offset += 4;
+  view.setUint16(offset, format, true); offset += 2;
+  view.setUint16(offset, numChannels, true); offset += 2;
+  view.setUint32(offset, sampleRate, true); offset += 4;
+  view.setUint32(offset, byteRate, true); offset += 4;
+  view.setUint16(offset, blockAlign, true); offset += 2;
+  view.setUint16(offset, bitDepth, true); offset += 2;
+  writeString('data');
+  view.setUint32(offset, dataLength, true); offset += 4;
+  const interleaved = new DataView(arrayBuffer, offset);
+  let idx = 0;
+  for (let i = 0; i < samples; i++) {
+    for (let ch = 0; ch < numChannels; ch++) {
+      let sample = buffer.getChannelData(ch)[i];
+      sample = Math.max(-1, Math.min(1, sample));
+      sample = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
+      interleaved.setInt16(idx, sample, true);
+      idx += 2;
+    }
+  }
+  return new Blob([arrayBuffer], { type: 'audio/wav' });
+}

--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -44,6 +44,19 @@ export function initZoomControls(ws, container, duration, applyZoomCallback, wra
     expandBtn.classList.toggle('active', isExpandMode);
   }
 
+  function setExpandMode(val) {
+    if (isExpandMode === val) return;
+    isExpandMode = val;
+    computeMinZoomLevel();
+    if (isExpandMode) {
+      zoomLevel = minZoomLevel;
+    } else {
+      zoomLevel = Math.max(minZoomLevel, 500);
+    }
+    applyZoom();
+    updateZoomButtons();
+  }
+
   zoomInBtn.onclick = () => {
     if (!isExpandMode && zoomLevel < 2500) {
       zoomLevel = Math.min(zoomLevel + 500, 2500);
@@ -62,15 +75,7 @@ export function initZoomControls(ws, container, duration, applyZoomCallback, wra
   };
 
   expandBtn.onclick = () => {
-    isExpandMode = !isExpandMode;
-    computeMinZoomLevel();
-    if (isExpandMode) {
-      zoomLevel = minZoomLevel;
-    } else {
-      zoomLevel = Math.max(minZoomLevel, 500);
-    }
-    applyZoom();
-    updateZoomButtons();
+    setExpandMode(!isExpandMode);
   };
 
   document.addEventListener('keydown', (e) => {
@@ -101,6 +106,7 @@ export function initZoomControls(ws, container, duration, applyZoomCallback, wra
       zoomLevel = Math.max(newZoom, minZoomLevel);
       applyZoom();
     },
+    setExpandMode,
     isExpandMode: () => isExpandMode,
     forceExpandMode: () => {
       computeMinZoomLevel();

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -200,6 +200,7 @@
     import { initFileLoader, getWavSampleRate } from './modules/fileLoader.js';
     import { initBrightnessControl } from './modules/brightnessControl.js';
     import { initFrequencyHover } from './modules/frequencyHover.js';
+    import { cropWavBlob } from './modules/cropAudio.js';
     import { drawTimeAxis, drawFrequencyGrid } from './modules/axisRenderer.js';
     import { initExportCsv } from './modules/exportCsv.js';
     import { initTrashProgram } from './modules/trashProgram.js';
@@ -474,13 +475,17 @@
       () => { freqHoverControl?.refreshHover(); }
     );
 
-    viewer.addEventListener('expand-selection', (e) => {
+    viewer.addEventListener('expand-selection', async (e) => {
       const { startTime, endTime } = e.detail;
-      const seg = endTime - startTime;
-      if (seg > 0) {
-        const targetZoom = wrapper.clientWidth / seg;
-        zoomControl.setZoomLevel(targetZoom);
-        viewer.scrollLeft = startTime * targetZoom;
+      if (endTime > startTime) {
+        const file = getCurrentFile();
+        const blob = await cropWavBlob(file, startTime, endTime);
+        if (blob) {
+          await getWavesurfer().loadBlob(blob);
+          zoomControl.setExpandMode(true);
+          renderAxes();
+          freqHoverControl?.clearSelections();
+        }
       }
     });
     


### PR DESCRIPTION
## Summary
- add audio cropping helper to create WAV blobs from selection
- allow zoom control to set expand mode programmatically
- handle `expand-selection` by reloading a cropped audio segment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a9b3cbe5c832aa220dd7b98346adf