### PR TITLE
Hide hover lines over expand selection button

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -229,6 +229,8 @@ export function initFrequencyHover({
           detail: { startTime, endTime }
         }));
       });
+      expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
+      expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
       rectObj.appendChild(expandBtn);
     }
 


### PR DESCRIPTION
## Summary
- tweak frequency hover handler to hide hover lines when hovering the selection expand button

## Testing
- `node -c modules/frequencyHover.js`


------
https://chatgpt.com/codex/tasks/task_e_686aa2061ce4832abdaf412ff141e773