### PR TITLE
Handle selection expand mode disabling sampling rate

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -236,6 +236,8 @@
     let currentOverlap = 'auto';
     let overlapWarningShown = false;
     let freqHoverControl = null;
+    const sampleRateBtn = document.getElementById('sampleRateInput');
+    let selectionExpandMode = false;
     const getDuration = () => duration;
 
     const guanoOutput = document.getElementById('guano-output');
@@ -474,6 +476,12 @@
       () => { freqHoverControl?.hideHover(); },
       () => { freqHoverControl?.refreshHover(); }
     );
+    document.getElementById('expand-btn').addEventListener('click', () => {
+      if (!zoomControl.isExpandMode()) {
+        selectionExpandMode = false;
+        sampleRateBtn.disabled = false;
+      }
+    });
 
     viewer.addEventListener('expand-selection', async (e) => {
       const { startTime, endTime } = e.detail;
@@ -483,6 +491,8 @@
         if (blob) {
           await getWavesurfer().loadBlob(blob);
           zoomControl.setExpandMode(true);
+          selectionExpandMode = true;
+          sampleRateBtn.disabled = true;
           renderAxes();
           freqHoverControl?.clearSelections();
         }
@@ -835,6 +845,13 @@
         zoomControl.setZoomLevel(1000);
       }
       lastLoadedFileName = currentFile ? currentFile.name : null;
+      selectionExpandMode = false;
+      sampleRateBtn.disabled = false;
+    });
+
+    document.addEventListener('file-list-cleared', () => {
+      selectionExpandMode = false;
+      sampleRateBtn.disabled = false;
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -801,6 +801,11 @@ input.tag-button.editing {
 .dropdown-button:hover {
   background-color: #d5d5d5;
 }
+.dropdown-button:disabled {
+  background-color: #eee;
+  color: #aaa;
+  cursor: not-allowed;
+}
 .dropdown-button::after {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Summary
- track when a selection is expanded
- disable sampling rate dropdown while expanded
- restore dropdown on exit
- show disabled dropdown in gray

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686afff50044832a9005fbeddff69cbd