### PR TITLE
Fix max zoom level in expand selection mode

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -491,8 +491,8 @@
         const blob = await cropWavBlob(file, startTime, endTime);
         if (blob) {
           await getWavesurfer().loadBlob(blob);
-          zoomControl.setExpandMode(true);
           selectionExpandMode = true;
+          zoomControl.setExpandMode(true);
           sampleRateBtn.disabled = true;
           renderAxes();
           freqHoverControl?.clearSelections();


### PR DESCRIPTION
## Summary
- ensure `selectionExpandMode` is set before enabling zoom control expand mode so computeMaxZoomLevel sees the updated value

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_686b08a158d8832a8160d0577d6e5c96