### PR TITLE
Force min zoom on load

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -868,22 +868,17 @@
       }
     });
 
-    document.addEventListener('file-loaded', () => {
-      const currentFile = getCurrentFile();
-      duration = getWavesurfer().getDuration();
-      if (duration > 6) {
+      document.addEventListener('file-loaded', () => {
+        const currentFile = getCurrentFile();
+        duration = getWavesurfer().getDuration();
         zoomControl.setZoomLevel(0);
-      } else if (currentFile && currentFile.name !== lastLoadedFileName &&
-                 !zoomControl.isExpandMode() && zoomControl.getZoomLevel() > 1000) {
-        zoomControl.setZoomLevel(1000);
-      }
-      lastLoadedFileName = currentFile ? currentFile.name : null;
-      selectionExpandMode = false;
-      sampleRateBtn.disabled = false;
-      expandHistory = [];
-      currentExpandBlob = null;
-      updateExpandBackBtn();
-    });
+        lastLoadedFileName = currentFile ? currentFile.name : null;
+        selectionExpandMode = false;
+        sampleRateBtn.disabled = false;
+        expandHistory = [];
+        currentExpandBlob = null;
+        updateExpandBackBtn();
+      });
 
     document.addEventListener('file-list-cleared', () => {
       selectionExpandMode = false;


### PR DESCRIPTION
## Summary
- always apply minimum zoom level when loading a WAV file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b250ceb30832a969bea9f3a9a8746