### PR TITLE
Fix Ctrl+Arrow conflict

### DIFF
--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -175,6 +175,7 @@ export function initFileLoader({
   });
 
   document.addEventListener('keydown', (e) => {
+    if (e.ctrlKey) return; // avoid conflict with zoom shortcuts
     if (e.key === 'ArrowUp') {
       e.preventDefault();
       prevBtn.click();


### PR DESCRIPTION
## Summary
- prevent file navigation when using Ctrl+Up/Down zoom shortcuts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b28604fe4832abde535ca2e2187dd