### PR TITLE
Fix slow reload when expand mode active

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -871,6 +871,7 @@
       document.addEventListener('file-loaded', () => {
         const currentFile = getCurrentFile();
         duration = getWavesurfer().getDuration();
+        zoomControl.setExpandMode(false);
         zoomControl.setZoomLevel(0);
         lastLoadedFileName = currentFile ? currentFile.name : null;
         selectionExpandMode = false;


### PR DESCRIPTION
## Summary
- reset expand mode whenever a file is loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b343bddd8832aaddb3eca42001b56