### PR TITLE
Fix selection expand reload speed

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -309,6 +309,13 @@
         }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
+        if (selectionExpandMode) {
+          selectionExpandMode = false;
+          sampleRateBtn.disabled = false;
+          expandHistory = [];
+          currentExpandBlob = null;
+          updateExpandBackBtn();
+        }
       },
       onAfterLoad: () => {
         if (uploadOverlay.style.display !== 'flex') {


### PR DESCRIPTION
## Summary
- stop expand mode before loading a new file

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686b392e6838832aaad856d1d29b259d