### PR TITLE
Fix slow reload with active expand mode

### DIFF
--- a/modules/cropAudio.js
+++ b/modules/cropAudio.js
@@ -1,6 +1,8 @@
-export async function cropWavBlob(file, startTime, endTime) {
+export async function cropWavBlob(file, startTime, endTime, abortSignal = null) {
   if (!file) return null;
+  if (abortSignal?.aborted) return null;
   const buf = await file.arrayBuffer();
+  if (abortSignal?.aborted) return null;
   const view = new DataView(buf);
 
   let fmtOffset = -1;
@@ -55,5 +57,6 @@ export async function cropWavBlob(file, startTime, endTime) {
   outView.setUint32(4, output.length - 8, true); // update RIFF chunk size
   outView.setUint32(dataOffset - 4, newDataLength, true); // update data chunk size
 
+  if (abortSignal?.aborted) return null;
   return new Blob([output.buffer], { type: file.type || 'audio/wav' });
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -243,6 +243,7 @@
     let selectionExpandMode = false;
     let expandHistory = [];
     let currentExpandBlob = null;
+    let cropAbortController = null;
     const expandBackBtn = document.getElementById('expandBackBtn');
     function updateExpandBackBtn() {
       expandBackBtn.style.display = expandHistory.length > 0 ? 'inline-flex' : 'none';
@@ -309,6 +310,7 @@
         }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
+        cropAbortController?.abort();
         if (selectionExpandMode) {
           selectionExpandMode = false;
           sampleRateBtn.disabled = false;
@@ -498,11 +500,16 @@
       const { startTime, endTime } = e.detail;
       if (endTime > startTime) {
         const base = currentExpandBlob || getCurrentFile();
-        const blob = await cropWavBlob(base, startTime, endTime);
+        if (cropAbortController) cropAbortController.abort();
+        cropAbortController = new AbortController();
+        const { signal } = cropAbortController;
+        const blob = await cropWavBlob(base, startTime, endTime, signal);
+        if (signal.aborted) return;
         if (blob) {
           expandHistory.push(base);
           await getWavesurfer().loadBlob(blob);
           currentExpandBlob = blob;
+          cropAbortController = null;
           selectionExpandMode = true;
           zoomControl.setZoomLevel(0);
           sampleRateBtn.disabled = true;
@@ -554,6 +561,7 @@
         }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
+        cropAbortController?.abort();
       },
       onAfterLoad: () => {
         if (uploadOverlay.style.display !== 'flex') {
@@ -852,12 +860,15 @@
     expandBackBtn.addEventListener('click', async () => {
       if (expandHistory.length === 0) return;
       const prev = expandHistory.pop();
+      cropAbortController?.abort();
       if (prev && prev.name !== undefined) {
         currentExpandBlob = null;
         await fileLoaderControl.loadFileAtIndex(getCurrentIndex());
+        cropAbortController = null;
       } else if (prev) {
         await getWavesurfer().loadBlob(prev);
         currentExpandBlob = prev;
+        cropAbortController = null;
         selectionExpandMode = true;
         zoomControl.setZoomLevel(0);
         sampleRateBtn.disabled = true;
@@ -884,6 +895,7 @@
         sampleRateBtn.disabled = false;
         expandHistory = [];
         currentExpandBlob = null;
+        cropAbortController = null;
         updateExpandBackBtn();
       });
 
@@ -892,6 +904,7 @@
       sampleRateBtn.disabled = false;
       expandHistory = [];
       currentExpandBlob = null;
+      cropAbortController = null;
       updateExpandBackBtn();
     });
   </script>


### PR DESCRIPTION
## Summary
- add optional abort signal to `cropWavBlob`
- use `AbortController` when cropping a selection
- cancel any in-progress crop when loading a new file or returning from expand

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b7a19c738832a90a96fdac123654b