### PR TITLE
Fix zoom delay when loading files

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -304,6 +304,7 @@
         sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
+        zoomControl.setZoomLevel(0);
         if (uploadOverlay.style.display !== 'flex') {
           loadingOverlay.style.display = 'flex';
         }
@@ -549,6 +550,7 @@
         sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
+        zoomControl.setZoomLevel(0);
         if (uploadOverlay.style.display !== 'flex') {
           loadingOverlay.style.display = 'flex';
         }


### PR DESCRIPTION
## Summary
- reset zoom level to minimum before loading a new file

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b954e8900832aaf7f63e72adce53e