### PR TITLE
Fix delayed reload with active expand mode

### DIFF
--- a/modules/cropAudio.js
+++ b/modules/cropAudio.js
@@ -1,6 +1,8 @@
-export async function cropWavBlob(file, startTime, endTime) {
+export async function cropWavBlob(file, startTime, endTime, abortSignal = null) {
   if (!file) return null;
+  if (abortSignal?.aborted) return null;
   const buf = await file.arrayBuffer();
+  if (abortSignal?.aborted) return null;
   const view = new DataView(buf);
 
   let fmtOffset = -1;
@@ -55,5 +57,6 @@ export async function cropWavBlob(file, startTime, endTime) {
   outView.setUint32(4, output.length - 8, true); // update RIFF chunk size
   outView.setUint32(dataOffset - 4, newDataLength, true); // update data chunk size
 
+  if (abortSignal?.aborted) return null;
   return new Blob([output.buffer], { type: file.type || 'audio/wav' });
 }

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -3,8 +3,13 @@
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
 
+const sampleRateCache = new WeakMap();
+
 export async function getWavSampleRate(file) {
   if (!file) return 256000;
+  if (sampleRateCache.has(file)) {
+    return sampleRateCache.get(file);
+  }
   const buffer = await file.arrayBuffer();
   const view = new DataView(buffer);
   let pos = 12;
@@ -17,11 +22,14 @@ export async function getWavSampleRate(file) {
     );
     const chunkSize = view.getUint32(pos + 4, true);
     if (chunkId === 'fmt ') {
-      return view.getUint32(pos + 12, true);
+      const rate = view.getUint32(pos + 12, true);
+      sampleRateCache.set(file, rate);
+      return rate;
     }
     pos += 8 + chunkSize;
     if (chunkSize % 2 === 1) pos += 1; // word alignment
   }
+  sampleRateCache.set(file, 256000);
   return 256000;
 }
 

--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -133,6 +133,17 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
         zoomLevel = minZoomLevel;
         applyZoom();
       }
+    },
+    forceZoomLevel: (newZoom) => {
+      zoomLevel = newZoom;
+      if (ws && typeof ws.zoom === 'function') {
+        ws.zoom(newZoom);
+      }
+      const width = duration() * zoomLevel;
+      container.style.width = `${width}px`;
+      wrapperElement.style.width = `${width}px`;
+      applyZoomCallback();
+      updateZoomButtons();
     }
   };
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -243,6 +243,7 @@
     let selectionExpandMode = false;
     let expandHistory = [];
     let currentExpandBlob = null;
+    let cropAbortController = null;
     const expandBackBtn = document.getElementById('expandBackBtn');
     function updateExpandBackBtn() {
       expandBackBtn.style.display = expandHistory.length > 0 ? 'inline-flex' : 'none';
@@ -304,11 +305,13 @@
         sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
+        zoomControl.forceZoomLevel(250);
         if (uploadOverlay.style.display !== 'flex') {
           loadingOverlay.style.display = 'flex';
         }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
+        cropAbortController?.abort();
         if (selectionExpandMode) {
           selectionExpandMode = false;
           sampleRateBtn.disabled = false;
@@ -498,11 +501,16 @@
       const { startTime, endTime } = e.detail;
       if (endTime > startTime) {
         const base = currentExpandBlob || getCurrentFile();
-        const blob = await cropWavBlob(base, startTime, endTime);
+        if (cropAbortController) cropAbortController.abort();
+        cropAbortController = new AbortController();
+        const { signal } = cropAbortController;
+        const blob = await cropWavBlob(base, startTime, endTime, signal);
+        if (signal.aborted) return;
         if (blob) {
           expandHistory.push(base);
           await getWavesurfer().loadBlob(blob);
           currentExpandBlob = blob;
+          cropAbortController = null;
           selectionExpandMode = true;
           zoomControl.setZoomLevel(0);
           sampleRateBtn.disabled = true;
@@ -549,11 +557,13 @@
         sidebarControl.refresh(file.name);
       },
       onBeforeLoad: () => {
+        zoomControl.forceZoomLevel(250);
         if (uploadOverlay.style.display !== 'flex') {
           loadingOverlay.style.display = 'flex';
         }
         freqHoverControl?.hideHover();
         freqHoverControl?.clearSelections();
+        cropAbortController?.abort();
       },
       onAfterLoad: () => {
         if (uploadOverlay.style.display !== 'flex') {
@@ -852,12 +862,15 @@
     expandBackBtn.addEventListener('click', async () => {
       if (expandHistory.length === 0) return;
       const prev = expandHistory.pop();
+      cropAbortController?.abort();
       if (prev && prev.name !== undefined) {
         currentExpandBlob = null;
         await fileLoaderControl.loadFileAtIndex(getCurrentIndex());
+        cropAbortController = null;
       } else if (prev) {
         await getWavesurfer().loadBlob(prev);
         currentExpandBlob = prev;
+        cropAbortController = null;
         selectionExpandMode = true;
         zoomControl.setZoomLevel(0);
         sampleRateBtn.disabled = true;
@@ -884,6 +897,7 @@
         sampleRateBtn.disabled = false;
         expandHistory = [];
         currentExpandBlob = null;
+        cropAbortController = null;
         updateExpandBackBtn();
       });
 
@@ -892,6 +906,7 @@
       sampleRateBtn.disabled = false;
       expandHistory = [];
       currentExpandBlob = null;
+      cropAbortController = null;
       updateExpandBackBtn();
     });
   </script>


### PR DESCRIPTION
## Summary
- handle abort signal during cropping
- cache wav sample rate
- abort crop operations when switching files or exiting expand mode
- add forceZoomLevel to zoomControl
- reset zoom level to a fixed low value before loading a new file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b954e8900832aaf7f63e72adce53e