### PR TITLE
Fix min zoom level after cropping

### DIFF
--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -23,7 +23,9 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
   }
 
   function computeMinZoomLevel() {
-    let visibleWidth = wrapperElement.clientWidth;
+    let visibleWidth = wrapperElement.parentElement
+      ? wrapperElement.parentElement.clientWidth
+      : wrapperElement.clientWidth;
     const dur = duration();
     if (dur > 0) {
       minZoomLevel = Math.floor((visibleWidth - 2) / dur);


### PR DESCRIPTION
## Summary
- ensure min zoom level uses parent container width when resetting zoom

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b9cef9048832abe80b865bec9f58d