### PR TITLE
Fix zoom reset when loading cropped files

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -504,6 +504,7 @@
           await getWavesurfer().loadBlob(blob);
           currentExpandBlob = blob;
           selectionExpandMode = true;
+          wrapper.style.width = `${wrapper.parentElement.clientWidth}px`;
           zoomControl.setZoomLevel(0);
           sampleRateBtn.disabled = true;
           renderAxes();
@@ -859,6 +860,7 @@
         await getWavesurfer().loadBlob(prev);
         currentExpandBlob = prev;
         selectionExpandMode = true;
+        wrapper.style.width = `${wrapper.parentElement.clientWidth}px`;
         zoomControl.setZoomLevel(0);
         sampleRateBtn.disabled = true;
         renderAxes();
@@ -878,6 +880,7 @@
       document.addEventListener('file-loaded', () => {
         const currentFile = getCurrentFile();
         duration = getWavesurfer().getDuration();
+        wrapper.style.width = `${wrapper.parentElement.clientWidth}px`;
         zoomControl.setZoomLevel(0);
         lastLoadedFileName = currentFile ? currentFile.name : null;
         selectionExpandMode = false;


### PR DESCRIPTION
## Summary
- revert zoomControl minZoomLevel changes
- normalize wrapper width before applying zoom when loading a file or using expand-selection

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b9ee8bcc8832a9cdf1e84831ff1a0