### PR TITLE
Fix zoom min level after expanding selections

### DIFF
--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -23,9 +23,11 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
   }
 
   function computeMinZoomLevel() {
-    let visibleWidth = wrapperElement.clientWidth;
+    let visibleWidth = wrapperElement.parentElement
+      ? wrapperElement.parentElement.clientWidth
+      : wrapperElement.clientWidth;
     const dur = duration();
-    if (dur > 0) {
+    if (dur > 0 && visibleWidth > 0) {
       minZoomLevel = Math.floor((visibleWidth - 2) / dur);
     }
   }


### PR DESCRIPTION
## Summary
- compute minimum zoom level using the wrapper's parent width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bb99a8224832a8b647cac08301dea