### PR TITLE
Implement PNG caching for spectrogram

### DIFF
--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -2,6 +2,7 @@
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
+import { displayCachedSpectrogram } from './spectrogramCache.js';
 
 export async function getWavSampleRate(file) {
   if (!file) return 256000;
@@ -72,6 +73,8 @@ export function initFileLoader({
   async function loadFile(file) {
     if (!file) return;
     const detectedSampleRate = await getWavSampleRate(file);
+
+    displayCachedSpectrogram(file);
 
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();

--- a/modules/spectrogramCache.js
+++ b/modules/spectrogramCache.js
@@ -1,0 +1,29 @@
+const cache = new WeakMap();
+
+export function saveSpectrogram(key, dataUrl) {
+  if (key && dataUrl) {
+    cache.set(key, dataUrl);
+  }
+}
+
+export function getSpectrogram(key) {
+  return cache.get(key) || null;
+}
+
+export function displayCachedSpectrogram(key, containerId = 'spectrogram-only') {
+  const dataUrl = cache.get(key);
+  const container = document.getElementById(containerId);
+  const img = container ? container.querySelector('#spectrogram-img') : null;
+  const canvas = container ? container.querySelector('canvas') : null;
+  if (!container || !img) return false;
+  if (dataUrl) {
+    img.src = dataUrl;
+    img.style.display = 'block';
+    if (canvas) canvas.style.display = 'none';
+    return true;
+  } else {
+    img.style.display = 'none';
+    if (canvas) canvas.style.display = 'block';
+    return false;
+  }
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -149,7 +149,9 @@
               <div id="upload-progress-text" class="progress-text">0/0</div>
             </div>
             <div id="viewer-container">
-            <div id="spectrogram-only" style="height: 800px;"></div>
+            <div id="spectrogram-only" style="height: 800px; position: relative;">
+              <img id="spectrogram-img" style="position:absolute;top:0;left:0;width:100%;height:100%;display:none;" />
+            </div>
             <canvas id="freq-grid"></canvas>
           </div>
           <div id="fixed-overlay">
@@ -212,6 +214,7 @@
     import { initSidebar } from './modules/sidebar.js';
     import { initTagControl } from './modules/tagControl.js';
     import { initDropdown } from './modules/dropdown.js';
+    import { saveSpectrogram, displayCachedSpectrogram } from './modules/spectrogramCache.js';
     import { showMessageBox } from './modules/messageBox.js';
     import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
@@ -509,6 +512,14 @@
           renderAxes();
           freqHoverControl?.clearSelections();
           updateExpandBackBtn();
+          setTimeout(() => {
+            const canvas = document.querySelector('#spectrogram-only canvas');
+            if (canvas) {
+              const dataUrl = canvas.toDataURL('image/png');
+              saveSpectrogram(currentExpandBlob, dataUrl);
+              displayCachedSpectrogram(currentExpandBlob);
+            }
+          }, 300);
         }
       }
     });
@@ -865,6 +876,14 @@
         freqHoverControl?.clearSelections();
       }
       updateExpandBackBtn();
+      setTimeout(() => {
+        const canvas = document.querySelector('#spectrogram-only canvas');
+        if (canvas) {
+          const dataUrl = canvas.toDataURL('image/png');
+          saveSpectrogram(currentExpandBlob || prev, dataUrl);
+          displayCachedSpectrogram(currentExpandBlob || prev);
+        }
+      }, 300);
     });
 
     document.addEventListener('keydown', (e) => {
@@ -875,17 +894,26 @@
       }
     });
 
-      document.addEventListener('file-loaded', () => {
-        const currentFile = getCurrentFile();
-        duration = getWavesurfer().getDuration();
-        zoomControl.setZoomLevel(0);
-        lastLoadedFileName = currentFile ? currentFile.name : null;
-        selectionExpandMode = false;
-        sampleRateBtn.disabled = false;
-        expandHistory = [];
-        currentExpandBlob = null;
-        updateExpandBackBtn();
-      });
+    document.addEventListener('file-loaded', () => {
+      const currentFile = getCurrentFile();
+      duration = getWavesurfer().getDuration();
+      zoomControl.setZoomLevel(0);
+      lastLoadedFileName = currentFile ? currentFile.name : null;
+      selectionExpandMode = false;
+      sampleRateBtn.disabled = false;
+      expandHistory = [];
+      currentExpandBlob = null;
+      updateExpandBackBtn();
+      setTimeout(() => {
+        const canvas = document.querySelector('#spectrogram-only canvas');
+        if (canvas) {
+          const dataUrl = canvas.toDataURL('image/png');
+          const key = currentExpandBlob || currentFile;
+          saveSpectrogram(key, dataUrl);
+          displayCachedSpectrogram(key);
+        }
+      }, 300);
+    });
 
     document.addEventListener('file-list-cleared', () => {
       selectionExpandMode = false;


### PR DESCRIPTION
## Summary
- add a small cache module to store rendered spectrogram images
- show cached spectrograms when loading wav files
- save PNG images after rendering selections or files
- embed an image element for displaying cached spectrograms

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686bde2865cc832a9c95a6c91a65abc0