### PR TITLE
Fix file input reload after clearing

### DIFF
--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -153,6 +153,8 @@ export function initFileLoader({
     }
     hideUploadOverlay();
     await loadFile(selectedFile);
+    // reset value so that selecting the same file again triggers change
+    fileInput.value = '';
   });
 
   prevBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- reset file input value after loading to allow loading the same file again

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d247ccd70832aab71a9d52c0cccc1