### PR TITLE
Fix hoverline hiding after expanding selection

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -264,6 +264,11 @@ export function initFrequencyHover({
           detail: { startTime, endTime }
         }));
       });
+      // Prevent accidental resize initiation when clicking near the button edges
+      // which could leave the hover indicators hidden after expanding
+      expandBtn.addEventListener('mousedown', (ev) => {
+        ev.stopPropagation();
+      });
       expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
       expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
       rectObj.appendChild(expandBtn);


### PR DESCRIPTION
## Summary
- prevent resize mousedown from firing when clicking the expand button

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_686d2b2657dc832a95c4a9e530f9a860