### PR TITLE
Hide drop overlay when uploading files

### DIFF
--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -50,6 +50,7 @@ export function initFileLoader({
 
   function showUploadOverlay(total) {
     if (!uploadOverlay) return;
+    document.dispatchEvent(new Event('drop-overlay-hide'));
     if (uploadProgressBar) uploadProgressBar.style.width = '0%';
     if (uploadProgressText) uploadProgressText.textContent = `0/${total}`;
     uploadOverlay.style.display = 'flex';


### PR DESCRIPTION
## Summary
- hide drop overlay while the upload overlay is active when using the file input

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686d30e2b1d0832abd41616b46cee88a