### PR TITLE
Persist routes on map popup

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -639,8 +639,6 @@ export function initMapPopup({
     if (popup.style.display === 'block') {
       popup.style.display = 'none';
       document.body.classList.remove('map-open');
-      clearRoute();
-      clearKmlRoute();
       if (textMode) toggleTextMode();
     } else {
       popup.style.display = 'block';


### PR DESCRIPTION
## Summary
- keep drawn routes and imported KML lines when closing the map popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d4712e8bc832aa81f2e1ee71a80fe