### PR TITLE
Ensure text/draw tools close each other

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -460,6 +460,10 @@ export function initMapPopup({
 
   function toggleDrawControl() {
     if (!drawControl) return;
+    const willShow = !drawControlVisible;
+    if (willShow && textMode) {
+      toggleTextMode();
+    }
     if (drawControlVisible) {
       map.removeControl(drawControl);
       drawBtn?.classList.remove('active');
@@ -575,7 +579,11 @@ export function initMapPopup({
   }
 
   function toggleTextMode() {
-    textMode = !textMode;
+    const newMode = !textMode;
+    if (newMode && drawControlVisible) {
+      toggleDrawControl();
+    }
+    textMode = newMode;
     textBtn?.classList.toggle('active', textMode);
     if (textMode) {
       map.on('click', onMapTextClick);


### PR DESCRIPTION
## Summary
- close texting mode when enabling drawing tool
- close drawing tool when enabling texting mode

## Testing
- `node --check modules/mapPopup.js`

------
https://chatgpt.com/codex/tasks/task_e_686d4b8509fc832a92e5235d6e6e2456