### PR TITLE
Fix text input position on map

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -504,6 +504,7 @@ export function initMapPopup({
   input.rows = 1;
   input.style.left = `${point.x}px`;
   input.style.top = `${point.y}px`;
+  input.style.transform = 'translate(-50%, -100%)';
   map.getContainer().appendChild(input);
   activeTextInput = input;
   map.dragging.disable();

--- a/style.css
+++ b/style.css
@@ -1090,4 +1090,5 @@ input.tag-button.editing {
   z-index: 1000;
   overflow: hidden;
   resize: none;
+  transform: translate(-50%, -100%);
 }


### PR DESCRIPTION
## Summary
- show map text input directly above click point
- center input with CSS transform

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dac037e38832a858ea2f2e6b06873