### PR TITLE
Center text markers on click location

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -490,7 +490,8 @@ export function initMapPopup({
       : '';
     return L.divIcon({
       className: 'map-text-icon',
-      html: `<span class="map-text-label"${titleAttr}>${escapeHtml(text)}</span>`
+      html: `<span class="map-text-label"${titleAttr}>${escapeHtml(text)}</span>`,
+      iconAnchor: [0, 0]
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -1067,6 +1067,7 @@ input.tag-button.editing {
   height: auto !important;
   margin: 0 !important;
   padding: 0 !important;
+  transform: translate(-50%, -50%);
 }
 
 .map-text-label {


### PR DESCRIPTION
## Summary
- center text icons at the clicked point
- add CSS transform so text markers appear centered

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686dae43ea40832ab07f92e176d218ea