### PR TITLE
Add right-click coordinate copy on Leaflet map

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -67,6 +67,8 @@ export function initMapPopup({
   const coordScaleWrapper = mapDiv.querySelector('.coord-scale-wrapper');
   const coordDisplay = mapDiv.querySelector('#coord-display');
   const noCoordMsg = mapDiv.querySelector('#no-coord-message');
+  const copyCoordMsg = mapDiv.querySelector('#copy-coord-message');
+  let copyMsgTimer = null;
   let scaleControl = null;
   const kmlInput = document.createElement('input');
   kmlInput.type = 'file';
@@ -98,6 +100,15 @@ export function initMapPopup({
 
   function hideNoCoordMessage() {
     if (noCoordMsg) noCoordMsg.style.display = 'none';
+  }
+
+  function showCopyCoordMessage() {
+    if (!copyCoordMsg) return;
+    copyCoordMsg.style.display = 'flex';
+    clearTimeout(copyMsgTimer);
+    copyMsgTimer = setTimeout(() => {
+      copyCoordMsg.style.display = 'none';
+    }, 3000);
   }
 
   mapDiv.addEventListener('dragenter', (e) => {
@@ -160,6 +171,13 @@ export function initMapPopup({
     map.on('mousemove', (e) => updateCoords(e.latlng));
     map.on('move', () => updateCoords(map.getCenter()));
     updateCoords(map.getCenter());
+
+    map.on('contextmenu', (e) => {
+      const { lat, lng } = e.latlng;
+      const text = `${lat.toFixed(6)}\t${lng.toFixed(6)}`;
+      navigator.clipboard?.writeText(text).catch(() => {});
+      showCopyCoordMessage();
+    });
 
     const osmAttr = { attribution: '&copy; OpenStreetMap contributors' };
     const esriAttr = { attribution: '&copy; Esri' };

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -185,6 +185,7 @@
       </div>
       <div class="coord-scale-wrapper"><span id="coord-display"></span></div>
       <div id="no-coord-message" class="coord-scale-wrapper" style="top:0; left:50%; transform:translateX(-50%); margin-top:10px; bottom:auto; display:none;">This wav file without coordinates</div>
+      <div id="copy-coord-message" class="coord-scale-wrapper" style="top:0; left:50%; transform:translateX(-50%); margin-top:10px; bottom:auto; display:none;">The coordinates have been copied to the clipboard</div>
     </div>
   </div>
   </div>


### PR DESCRIPTION
## Summary
- copy map coordinates to the clipboard on right-click
- show temporary message when coordinates are copied

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686dc6b36ef8832a867f37b56d21c870