### PR TITLE
Add automatic KML load on folder drop

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -4,6 +4,7 @@ import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { getWavSampleRate, getWavDuration } from './fileLoader.js';
 import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
 import { showMessageBox } from './messageBox.js';
+import { importKmlFile } from './mapPopup.js';
 
 export function initDragDropLoader({
   targetElementId,
@@ -111,6 +112,11 @@ export function initDragDropLoader({
   }
 
   async function handleFiles(files) {
+    const kmlFile = Array.from(files).find(f => f.name.toLowerCase().endsWith('.kml'));
+    if (kmlFile) {
+      importKmlFile(kmlFile);
+    }
+
     const validFiles = Array.from(files).filter(file => file.type === 'audio/wav' || file.name.endsWith('.wav'));
     if (validFiles.length === 0) {
       showMessageBox({

--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -1,5 +1,7 @@
 import { getCurrentIndex, getFileMetadata, getFileList } from './fileState.js';
 
+let importKmlFileFn = null;
+
 export function initMapPopup({
   buttonId = 'mapBtn',
   popupId = 'mapPopup',
@@ -153,18 +155,8 @@ export function initMapPopup({
     dropCounter = 0;
     hideMapDropOverlay();
     const file = Array.from(e.dataTransfer.files).find(f => f.name.endsWith('.kml'));
-    if (!file) return;
-    const text = await file.text();
-    const lines = parseKml(text);
-    clearKmlRoute();
-    const allCoords = [];
-    lines.forEach(coords => {
-      const line = L.polyline(coords, { color: 'deeppink', weight: 2, opacity: 0.8 }).addTo(map);
-      kmlPolylines.push(line);
-      allCoords.push(...coords);
-    });
-    if (allCoords.length > 0) {
-      map.fitBounds(allCoords);
+    if (file) {
+      await importKml(file);
     }
   });
 
@@ -419,6 +411,24 @@ export function initMapPopup({
     kmlPolylines = [];
   }
 
+  async function importKml(file) {
+    if (!file) return;
+    const text = await file.text();
+    const lines = parseKml(text);
+    clearKmlRoute();
+    const allCoords = [];
+    lines.forEach(coords => {
+      const line = L.polyline(coords, { color: 'deeppink', weight: 2, opacity: 0.8 }).addTo(map);
+      kmlPolylines.push(line);
+      allCoords.push(...coords);
+    });
+    if (allCoords.length > 0) {
+      map.fitBounds(allCoords);
+    }
+  }
+
+  importKmlFileFn = importKml;
+
   function parseKml(text) {
     const parser = new DOMParser();
     const doc = parser.parseFromString(text, 'text/xml');
@@ -439,18 +449,8 @@ export function initMapPopup({
 
   kmlInput.addEventListener('change', async () => {
     const file = kmlInput.files[0];
-    if (!file) return;
-    const text = await file.text();
-    const lines = parseKml(text);
-    clearKmlRoute();
-    const allCoords = [];
-    lines.forEach(coords => {
-      const line = L.polyline(coords, { color: 'deeppink', weight: 2, opacity: 0.8 }).addTo(map);
-      kmlPolylines.push(line);
-      allCoords.push(...coords);
-    });
-    if (allCoords.length > 0) {
-      map.fitBounds(allCoords);
+    if (file) {
+      await importKml(file);
     }
   });
 
@@ -850,4 +850,10 @@ export function initMapPopup({
   }
   document.addEventListener('file-loaded', updateMap);
   document.addEventListener('file-list-cleared', () => refreshMarkers());
+}
+
+export async function importKmlFile(file) {
+  if (importKmlFileFn && file) {
+    await importKmlFileFn(file);
+  }
 }


### PR DESCRIPTION
## Summary
- export a new `importKmlFile` function from the map module
- refactor KML import logic so it can be reused
- call `importKmlFile` when dropping folders that contain `.kml` files

## Testing
- `node --check modules/dragDropLoader.js`
- `node --check modules/mapPopup.js`

------
https://chatgpt.com/codex/tasks/task_e_686e041e4074832a891699dfa85dd442