### PR TITLE
Fix KML import when dropping folders

### DIFF
--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -111,10 +111,12 @@ export function initDragDropLoader({
     document.dispatchEvent(new Event('file-loaded'));
   }
 
+  let pendingKmlFile = null;
+
   async function handleFiles(files) {
     const kmlFile = Array.from(files).find(f => f.name.toLowerCase().endsWith('.kml'));
     if (kmlFile) {
-      importKmlFile(kmlFile);
+      pendingKmlFile = kmlFile;
     }
 
     const validFiles = Array.from(files).filter(file => file.type === 'audio/wav' || file.name.endsWith('.wav'));
@@ -164,6 +166,10 @@ export function initDragDropLoader({
     hideUploadOverlay();
     if (filteredList.length > 0) {
       await loadFile(filteredList[0]);
+      if (pendingKmlFile) {
+        await importKmlFile(pendingKmlFile);
+        pendingKmlFile = null;
+      }
     }
     if (skippedLong > 0) {
       showMessageBox({


### PR DESCRIPTION
## Summary
- ensure KML files dropped with folders are loaded after the first audio file

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686e0761a0e4832a8f49b67257432104