### PR TITLE
Add OffscreenCanvas caching worker

### DIFF
--- a/main.js
+++ b/main.js
@@ -57,6 +57,39 @@ const canvasElem = document.getElementById("spectrogram-canvas");
 const offscreen = canvasElem.transferControlToOffscreen();
 const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
 specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+const spectrogramCache = new Map();
+specWorker.onmessage = (e) => {
+  if (e.data.type === 'preloaded') {
+    spectrogramCache.set(e.data.key, e.data.imageData);
+  }
+};
+
+function displayCached(file) {
+  const cached = spectrogramCache.get(file.name);
+  if (cached) {
+    specWorker.postMessage({ type: 'display', imageData: cached });
+  }
+}
+
+async function preloadNextFile() {
+  const idx = getCurrentIndex();
+  const files = getFileList();
+  if (idx >= 0 && idx < files.length - 1) {
+    const nextFile = files[idx + 1];
+    if (spectrogramCache.has(nextFile.name)) return;
+    const arrayBuf = await nextFile.arrayBuffer();
+    const ac = new (window.AudioContext || window.webkitAudioContext)();
+    const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));
+    specWorker.postMessage({
+      type: 'preload',
+      key: nextFile.name,
+      buffer: audioBuf.getChannelData(0),
+      sampleRate: audioBuf.sampleRate,
+      fftSize: currentFftSize,
+      overlap: getOverlapPercent()
+    }, [audioBuf.getChannelData(0).buffer]);
+  }
+}
 function updateExpandBackBtn() {
 expandBackBtn.style.display = expandHistory.length > 0 ? 'inline-flex' : 'none';
 }
@@ -111,11 +144,12 @@ wavesurfer: getWavesurfer(),
 spectrogramHeight,
 colorMap: [],
 onPluginReplaced: () => {},
-onFileLoaded: (file) => {
-hideDropOverlay();
-zoomControlsElem.style.display = 'flex';
-sidebarControl.refresh(file.name);
-},
+  onFileLoaded: (file) => {
+    hideDropOverlay();
+    zoomControlsElem.style.display = 'flex';
+    sidebarControl.refresh(file.name);
+    displayCached(file);
+  },
 onBeforeLoad: () => {
 if (uploadOverlay.style.display !== 'flex') {
 loadingOverlay.style.display = 'flex';
@@ -717,6 +751,7 @@ document.addEventListener("file-loaded", async () => {
     const ac = new (window.AudioContext || window.webkitAudioContext)();
     const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));
     specWorker.postMessage({ type: "render", buffer: audioBuf.getChannelData(0), sampleRate: audioBuf.sampleRate, fftSize: currentFftSize, overlap: getOverlapPercent() }, [audioBuf.getChannelData(0).buffer]);
+    preloadNextFile();
   }
 });
 

--- a/spectrogramWorker.js
+++ b/spectrogramWorker.js
@@ -8,17 +8,28 @@ self.onmessage = (e) => {
     ctx = canvas.getContext('2d');
   } else if (type === 'render') {
     if (!ctx) return;
-    renderSpectrogram(e.data.buffer, e.data.sampleRate || sampleRate, e.data.fftSize || 1024, e.data.overlap || 0);
+    const img = computeImageData(e.data.buffer, e.data.fftSize || 1024, e.data.overlap || 0);
+    canvas.width = img.width;
+    canvas.height = img.height;
+    ctx.putImageData(img, 0, 0);
+    self.postMessage({ type: 'rendered' });
+  } else if (type === 'preload') {
+    const img = computeImageData(e.data.buffer, e.data.fftSize || 1024, e.data.overlap || 0);
+    self.postMessage({ type: 'preloaded', key: e.data.key, imageData: img });
+  } else if (type === 'display') {
+    if (!ctx) return;
+    const img = e.data.imageData;
+    canvas.width = img.width;
+    canvas.height = img.height;
+    ctx.putImageData(img, 0, 0);
   }
 };
 
-function renderSpectrogram(signal, sr, fftSize, overlapPct) {
+function computeImageData(signal, fftSize, overlapPct) {
   const hop = Math.max(1, Math.floor(fftSize * (1 - overlapPct / 100)));
   const width = Math.max(1, Math.ceil((signal.length - fftSize) / hop));
   const height = fftSize / 2;
-  canvas.width = width;
-  canvas.height = height;
-  const img = ctx.createImageData(width, height);
+  const img = new ImageData(width, height);
   const window = hannWindow(fftSize);
   const real = new Float32Array(fftSize);
   const imag = new Float32Array(fftSize);
@@ -40,8 +51,7 @@ function renderSpectrogram(signal, sr, fftSize, overlapPct) {
       img.data[idx * 4 + 3] = 255;
     }
   }
-  ctx.putImageData(img, 0, 0);
-  self.postMessage({ type: 'rendered' });
+  return img;
 }
 
 function hannWindow(N) {


### PR DESCRIPTION
## Summary
- use `OffscreenCanvas` worker to cache rendered spectrograms
- preload the next wav file in the list
- draw cached spectrograms instantly on load

## Testing
- `node --check main.js`
- `node --check spectrogramWorker.js`

------
https://chatgpt.com/codex/tasks/task_e_686e3a641970832aace8471a33ccf53a