### PR TITLE
Add quick preset button

### DIFF
--- a/main.js
+++ b/main.js
@@ -456,6 +456,15 @@ currentOverlap = 'auto';
 handleOverlapChange();
 });
 
+const quickPresetBtn = document.getElementById('quickPresetBtn');
+quickPresetBtn.addEventListener('click', () => {
+  fftSizeDropdown.select(0);
+  overlapInput.value = '';
+  currentOverlap = 'auto';
+  handleOverlapChange();
+  sampleRateDropdown.select(3);
+});
+
 function updateSpectrogramSettingsText() {
 const settingBox = document.getElementById('spectrogram-settings');
 const sampleRate = currentSampleRate;

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -85,6 +85,7 @@
         </label>
         <label class="slider-label">Overlap
           <input type="number" id="overlapInput" title="Overlap Size (1-99)" placeholder="Auto" min="1" max="99" step="1">
+          <button id="quickPresetBtn" class="toolbar-button" title="Quick preset"><i class="fa-solid fa-bolt"></i></button>
         </label>
         <div class="toolbar-divider"></div>
         <label class="slider-label">F.Range


### PR DESCRIPTION
## Summary
- add quick preset button next to overlap field
- hook button to set Fs=256kHz, FFT=512 and Overlap=Auto, then reload file

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686faba8c2cc832ab00734f047b8ab13