### PR TITLE
Fix min zoom calculation after high zoom

### DIFF
--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -26,7 +26,12 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
   }
 
   function computeMinZoomLevel() {
-    let visibleWidth = wrapperElement.clientWidth;
+    // Use the parent's width rather than the wrapper's current width.
+    // The wrapper width may be expanded when zoomed in, leading to an
+    // overestimated min zoom on subsequent file loads.
+    let visibleWidth = wrapperElement.parentElement
+      ? wrapperElement.parentElement.clientWidth
+      : wrapperElement.clientWidth;
     const dur = duration();
     if (dur > 0) {
       minZoomLevel = Math.floor((visibleWidth - 2) / dur);


### PR DESCRIPTION
## Summary
- prevent inflated minimum zoom when another file loads

## Testing
- `node modules/zoomControl.js` *(fails: Nothing to run)*

------
https://chatgpt.com/codex/tasks/task_e_686fc4840654832a957a243757321313