### PR TITLE
Fix min zoom computation

### DIFF
--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -26,7 +26,16 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
   }
 
   function computeMinZoomLevel() {
-    let visibleWidth = wrapperElement.clientWidth;
+    // Reset the wrapper width so previous zoom levels don't affect
+    // the computed minimum zoom for newly loaded files.
+    wrapperElement.style.width = '';
+
+    // Use the visible width of the viewer wrapper's parent so
+    // reloading a new wav file after zooming doesn't use the
+    // previously expanded wrapper width.
+    let visibleWidth = wrapperElement.parentElement
+      ? wrapperElement.parentElement.clientWidth
+      : wrapperElement.clientWidth;
     const dur = duration();
     if (dur > 0) {
       minZoomLevel = Math.floor((visibleWidth - 2) / dur);


### PR DESCRIPTION
## Summary
- reset the viewer wrapper width before calculating the minimum zoom
- compute min zoom using the wrapper's parent width

## Testing
- `node -e "import('./modules/zoomControl.js').then(() => console.log('ok')).catch(e => console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_686fc4840654832a957a243757321313