### PR TITLE
Set min zoom using viewer width

### DIFF
--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -26,7 +26,10 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
   }
 
   function computeMinZoomLevel() {
-    let visibleWidth = wrapperElement.clientWidth;
+    const viewerContainer = document.getElementById('viewer-container');
+    const visibleWidth = viewerContainer
+      ? viewerContainer.getBoundingClientRect().width
+      : 0;
     const dur = duration();
     if (dur > 0) {
       minZoomLevel = Math.floor((visibleWidth - 2) / dur);


### PR DESCRIPTION
## Summary
- calculate `minZoomLevel` based on the current width of `#viewer-container`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fdc16a25c832a937050f7431150e4