### PR TITLE
Add color bar to spectrogram settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -103,7 +103,7 @@ freqHoverControl?.refreshHover();
 showDropOverlay();
 document.addEventListener('drop-overlay-show', showDropOverlay);
 document.addEventListener('drop-overlay-hide', hideDropOverlay);
-updateSpectrogramSettingsText();
+refreshSpectrogramSettings();
 
 fileLoaderControl = initFileLoader({
 fileInputId: 'fileInput',
@@ -135,7 +135,7 @@ if (uploadOverlay.style.display !== 'flex') {
 loadingOverlay.style.display = 'none';
 }
 freqHoverControl?.refreshHover();
-updateSpectrogramSettingsText();
+refreshSpectrogramSettings();
 },
 onSampleRateDetected: autoSetSampleRate
 });
@@ -230,7 +230,7 @@ renderAxes();
 freqHoverControl?.refreshHover();
 }
 );
-updateSpectrogramSettingsText();
+refreshSpectrogramSettings();
 }
 
 async function handleSampleRate(rate) {
@@ -241,7 +241,7 @@ if (cur) {
 const autoRate = await getWavSampleRate(cur);
 await autoSetSampleRate(autoRate);
 } else {
-updateSpectrogramSettingsText();
+    refreshSpectrogramSettings();
 }
 return;
 }
@@ -252,7 +252,7 @@ async function autoSetSampleRate(rate, skipReload = false) {
 if (selectedSampleRate === 'auto' && rate) {
 await applySampleRate(rate, !skipReload);
 } else if (selectedSampleRate === 'auto') {
-updateSpectrogramSettingsText();
+    refreshSpectrogramSettings();
 }
 }
 
@@ -332,7 +332,7 @@ brightnessValId: 'brightnessVal',
 gainValId: 'gainVal',
 resetBtnId: 'resetButton',
 onColorMapUpdated: (colorMap) => {
-freqHoverControl?.hideHover();        
+freqHoverControl?.hideHover();
 replacePlugin(
 colorMap,
 spectrogramHeight,
@@ -343,10 +343,12 @@ getOverlapPercent(),
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
 renderAxes();
-freqHoverControl?.refreshHover();            
-}
-);
-},
+  freqHoverControl?.refreshHover();
+  }
+  );
+  ensureColorBarAttached();
+  drawColorBar(colorMap);
+  },
 });
 
 initDragDropLoader({
@@ -372,7 +374,7 @@ if (uploadOverlay.style.display !== 'flex') {
 loadingOverlay.style.display = 'none';
 }
 freqHoverControl?.refreshHover();
-updateSpectrogramSettingsText();
+  refreshSpectrogramSettings();
 },
 onSampleRateDetected: autoSetSampleRate
 });
@@ -475,7 +477,42 @@ const windowType = 'Hanning';
 const overlapText = overlap !== null ? `${overlap}%` : 'Auto';
 settingBox.textContent =
 `Sampling rate: ${sampleRate / 1000}kHz, FFT size: ${fftSize}, Overlap size: ${overlapText}, ${windowType} window`;
-}    
+}
+
+function ensureColorBarAttached() {
+  const container = document.getElementById('spectrogram-settings');
+  if (!container) return;
+  let canvas = document.getElementById('color-bar');
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    canvas.id = 'color-bar';
+    canvas.width = 600;
+    canvas.height = 20;
+  }
+  if (!container.contains(canvas)) {
+    container.appendChild(canvas);
+  }
+  drawColorBar(getCurrentColorMap());
+}
+
+function refreshSpectrogramSettings() {
+  updateSpectrogramSettingsText();
+  ensureColorBarAttached();
+}
+
+function drawColorBar(colorMap) {
+  const canvas = document.getElementById('color-bar');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const width = canvas.width;
+  const height = canvas.height;
+  const step = width / colorMap.length;
+  for (let i = 0; i < colorMap.length; i++) {
+    const [r, g, b, a] = colorMap[i];
+    ctx.fillStyle = `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
+    ctx.fillRect(i * step, 0, step, height);
+  }
+}
 
 function getOverlapPercent() {
 if (currentOverlap === 'auto') return null;
@@ -518,7 +555,7 @@ freqHoverControl?.refreshHover();
 },
 currentFftSize
 );
-updateSpectrogramSettingsText();
+refreshSpectrogramSettings();
 }
 
 function handleOverlapChange() {
@@ -537,7 +574,7 @@ freqHoverControl?.refreshHover();
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
 renderAxes();
-updateSpectrogramSettingsText();
+refreshSpectrogramSettings();
 }
 
 function updateFrequencyRange(freqMin, freqMax) {
@@ -561,9 +598,9 @@ zoomControl.applyZoom();
 renderAxes();
 
 if (freqHoverControl) {
-freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
+  freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
 }
-updateSpectrogramSettingsText();
+refreshSpectrogramSettings();
 }
 
 const clearAllBtn = document.getElementById('clearAllBtn');

--- a/style.css
+++ b/style.css
@@ -1318,6 +1318,16 @@ input.tag-button.editing {
   font-size: 12px;
   font-family: 'Noto Sans HK', sans-serif;
   z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+#color-bar {
+  width: 600px;
+  height: 20px;
+  margin-left: 10px;
+  border: 1px solid #ccc;
 }
 
 .drop-border {


### PR DESCRIPTION
## Summary
- revert modifications to `updateSpectrogramSettingsText`
- add helper to attach color bar canvas and refresh on updates
- draw color bar when brightness or gain changes
- keep color bar present after settings updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6870f7f06348832abd13364b6132bfba