### PR TITLE
Add dynamic color bar

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,6 +21,7 @@ import { initMapPopup } from './modules/mapPopup.js';
 import { initSidebar } from './modules/sidebar.js';
 import { initTagControl } from './modules/tagControl.js';
 import { initDropdown } from './modules/dropdown.js';
+import { initColorBar, updateColorBar } from './modules/colorBar.js';
 import { showMessageBox } from './modules/messageBox.js';
 import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
@@ -38,6 +39,7 @@ const hoverLineElem = document.getElementById('hover-line');
 const hoverLineVElem = document.getElementById('hover-line-vertical');
 const hoverLabelElem = document.getElementById('hover-label');
 const zoomControlsElem = document.getElementById('zoom-controls');
+const colorBarCanvas = document.getElementById('colormap-bar');
 let duration = 0;
 let lastLoadedFileName = null;
 let currentFreqMin = 10;
@@ -104,6 +106,7 @@ showDropOverlay();
 document.addEventListener('drop-overlay-show', showDropOverlay);
 document.addEventListener('drop-overlay-hide', hideDropOverlay);
 updateSpectrogramSettingsText();
+initColorBar({ canvasId: 'colormap-bar' });
 
 fileLoaderControl = initFileLoader({
 fileInputId: 'fileInput',
@@ -227,9 +230,10 @@ getOverlapPercent(),
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
 renderAxes();
-freqHoverControl?.refreshHover();
-}
+  freqHoverControl?.refreshHover();
+  }
 );
+updateColorBar(getCurrentColorMap());
 updateSpectrogramSettingsText();
 }
 
@@ -343,9 +347,10 @@ getOverlapPercent(),
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
 renderAxes();
-freqHoverControl?.refreshHover();            
-}
+    freqHoverControl?.refreshHover();
+  }
 );
+updateColorBar(colorMap);
 },
 });
 
@@ -514,30 +519,33 @@ getOverlapPercent(),
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
 renderAxes();
-freqHoverControl?.refreshHover();
-},
-currentFftSize
+    freqHoverControl?.refreshHover();
+  },
+  currentFftSize
 );
+updateColorBar(colorMap);
 updateSpectrogramSettingsText();
 }
 
 function handleOverlapChange() {
 const colorMap = getCurrentColorMap();
 freqHoverControl?.hideHover();
-replacePlugin(
-colorMap,
-spectrogramHeight,
-currentFreqMin,
-currentFreqMax,
-getOverlapPercent()
-);
+  replacePlugin(
+    colorMap,
+    spectrogramHeight,
+    currentFreqMin,
+    currentFreqMax,
+    getOverlapPercent()
+  );
 
-freqHoverControl?.refreshHover();
+  freqHoverControl?.refreshHover();
 
-duration = getWavesurfer().getDuration();
-zoomControl.applyZoom();
-renderAxes();
-updateSpectrogramSettingsText();
+  updateColorBar(colorMap);
+
+  duration = getWavesurfer().getDuration();
+  zoomControl.applyZoom();
+  renderAxes();
+  updateSpectrogramSettingsText();
 }
 
 function updateFrequencyRange(freqMin, freqMax) {
@@ -546,39 +554,42 @@ currentFreqMin = freqMin;
 currentFreqMax = freqMax;
 
 freqHoverControl?.hideHover();
-replacePlugin(
-colorMap,
-spectrogramHeight,
-freqMin,
-freqMax,
-getOverlapPercent()
-);
+  replacePlugin(
+    colorMap,
+    spectrogramHeight,
+    freqMin,
+    freqMax,
+    getOverlapPercent()
+  );
 
-freqHoverControl?.refreshHover();
+  freqHoverControl?.refreshHover();
 
-duration = getWavesurfer().getDuration();
-zoomControl.applyZoom();
-renderAxes();
+  duration = getWavesurfer().getDuration();
+  zoomControl.applyZoom();
+  renderAxes();
 
-if (freqHoverControl) {
-freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
-}
-updateSpectrogramSettingsText();
+  updateColorBar(colorMap);
+
+  if (freqHoverControl) {
+    freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
+  }
+  updateSpectrogramSettingsText();
 }
 
 const clearAllBtn = document.getElementById('clearAllBtn');
 clearAllBtn.addEventListener('click', () => {
 clearFileList();
 sidebarControl.refresh('');
-replacePlugin(
-getCurrentColorMap(),
-spectrogramHeight,
-currentFreqMin,
-currentFreqMax,
-getOverlapPercent()
-);
-showDropOverlay();
-loadingOverlay.style.display = 'none';
+  replacePlugin(
+    getCurrentColorMap(),
+    spectrogramHeight,
+    currentFreqMin,
+    currentFreqMax,
+    getOverlapPercent()
+  );
+  updateColorBar(getCurrentColorMap());
+  showDropOverlay();
+  loadingOverlay.style.display = 'none';
 zoomControlsElem.style.display = 'none';
 guanoOutput.textContent = '(no file selected)';
 tagControl.updateTagButtonStates();
@@ -616,16 +627,17 @@ const removed = clearTrashFiles();
 if (removed > 0) {
 const remaining = getFileList();
 if (remaining.length === 0) {
-sidebarControl.refresh('');
-replacePlugin(
-getCurrentColorMap(),
-spectrogramHeight,
-currentFreqMin,
-currentFreqMax,
-getOverlapPercent()
-);
-showDropOverlay();
-loadingOverlay.style.display = 'none';
+    sidebarControl.refresh('');
+    replacePlugin(
+      getCurrentColorMap(),
+      spectrogramHeight,
+      currentFreqMin,
+      currentFreqMax,
+      getOverlapPercent()
+    );
+    updateColorBar(getCurrentColorMap());
+    showDropOverlay();
+    loadingOverlay.style.display = 'none';
 zoomControlsElem.style.display = 'none';
 guanoOutput.textContent = '(no file selected)';
 } else {

--- a/modules/colorBar.js
+++ b/modules/colorBar.js
@@ -1,0 +1,21 @@
+export let ctx = null;
+let canvasElem = null;
+export function initColorBar({ canvasId, width = 512, height = 16 }) {
+  canvasElem = document.getElementById(canvasId);
+  if (!canvasElem) return;
+  canvasElem.width = width;
+  canvasElem.height = height;
+  ctx = canvasElem.getContext('2d');
+}
+
+export function updateColorBar(colorMap) {
+  if (!ctx || !Array.isArray(colorMap)) return;
+  const width = canvasElem.width;
+  const height = canvasElem.height;
+  const step = width / colorMap.length;
+  for (let i = 0; i < colorMap.length; i++) {
+    const [r, g, b, a] = colorMap[i];
+    ctx.fillStyle = `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
+    ctx.fillRect(i * step, 0, step, height);
+  }
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -117,7 +117,9 @@
         </div>
       </div>
       <div id="whole-spectrogram">
-      <div id="spectrogram-settings"></div>
+      <div id="spectrogram-settings">
+        <canvas id="colormap-bar"></canvas>
+      </div>
       <div class="viewer-row">
         <div id="freq-labels"></div>
           <div id="viewer-wrapper">

--- a/style.css
+++ b/style.css
@@ -1318,6 +1318,15 @@ input.tag-button.editing {
   font-size: 12px;
   font-family: 'Noto Sans HK', sans-serif;
   z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#colormap-bar {
+  width: 512px;
+  height: 16px;
+  border: 1px solid #ccc;
 }
 
 .drop-border {


### PR DESCRIPTION
## Summary
- add color bar module for drawing current colormap
- render color bar in spectrogram settings and style it
- update main script to initialize and refresh the color bar whenever the spectrogram colormap changes

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6870fee42ba8832a8f255f8e18517763