### PR TITLE
Fix color bar and settings text rendering

### DIFF
--- a/main.js
+++ b/main.js
@@ -130,13 +130,14 @@ currentExpandBlob = null;
 updateExpandBackBtn();
 }
 },
-onAfterLoad: () => {
-if (uploadOverlay.style.display !== 'flex') {
-loadingOverlay.style.display = 'none';
-}
-freqHoverControl?.refreshHover();
-updateSpectrogramSettingsText();
-},
+  onAfterLoad: () => {
+    if (uploadOverlay.style.display !== 'flex') {
+      loadingOverlay.style.display = 'none';
+    }
+    freqHoverControl?.refreshHover();
+    drawColorBar(getCurrentColorMap());
+    updateSpectrogramSettingsText();
+  },
 onSampleRateDetected: autoSetSampleRate
 });
 sidebarControl = initSidebar({
@@ -368,13 +369,14 @@ loadingOverlay.style.display = 'flex';
 freqHoverControl?.hideHover();
 freqHoverControl?.clearSelections();
 },
-onAfterLoad: () => {
-if (uploadOverlay.style.display !== 'flex') {
-loadingOverlay.style.display = 'none';
-}
-freqHoverControl?.refreshHover();
-updateSpectrogramSettingsText();
-},
+  onAfterLoad: () => {
+    if (uploadOverlay.style.display !== 'flex') {
+      loadingOverlay.style.display = 'none';
+    }
+    freqHoverControl?.refreshHover();
+    drawColorBar(getCurrentColorMap());
+    updateSpectrogramSettingsText();
+  },
 onSampleRateDetected: autoSetSampleRate
 });
 

--- a/modules/brightnessControl.js
+++ b/modules/brightnessControl.js
@@ -45,12 +45,14 @@ export function initBrightnessControl({
     }
   }
 
-  // 事件綁定
-  brightnessSlider.addEventListener('input', updateSliderValues);
-  gainSlider.addEventListener('input', updateSliderValues);
+  // 事件綁定 - 在滑動時即時更新數值和顏色條
+  function handleInput() {
+    updateSliderValues();
+    updateColorMap();
+  }
 
-  brightnessSlider.addEventListener('change', updateColorMap);
-  gainSlider.addEventListener('change', updateColorMap);
+  brightnessSlider.addEventListener('input', handleInput);
+  gainSlider.addEventListener('input', handleInput);
 
   resetBtn.addEventListener('click', () => {
     brightnessSlider.value = defaultBrightness;

--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -24,7 +24,7 @@ export function initDragDropLoader({
   const uploadProgressText = document.getElementById('upload-progress-text');
   const fileNameElem = document.getElementById('fileNameText');
   const guanoOutput = document.getElementById('guano-output');
-  const spectrogramSettings = document.getElementById('spectrogram-settings');  
+  const spectrogramSettingsText = document.getElementById('spectrogram-settings-text');
   let lastObjectUrl = null;
 
   function showOverlay() {
@@ -100,10 +100,7 @@ export function initDragDropLoader({
       await onSampleRateDetected(sampleRate);
     }
 
-    if (spectrogramSettings) {
-      spectrogramSettings.textContent =
-        `Sampling rate: ${sampleRate / 1000}kHz`;
-    }
+
 
     if (typeof onAfterLoad === 'function') {
       onAfterLoad();

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -80,7 +80,7 @@ export function initFileLoader({
   const nextBtn = document.getElementById('nextBtn');
   const fileNameElem = document.getElementById('fileNameText');
   const guanoOutput = document.getElementById('guano-output');
-  const spectrogramSettings = document.getElementById('spectrogram-settings');
+  const spectrogramSettingsText = document.getElementById('spectrogram-settings-text');
   const uploadOverlay = document.getElementById('upload-overlay');
   const uploadProgressBar = document.getElementById('upload-progress-bar');
   const uploadProgressText = document.getElementById('upload-progress-text');
@@ -148,11 +148,6 @@ export function initFileLoader({
     }
 
     const sampleRate = detectedSampleRate || wavesurfer?.options?.sampleRate || 256000;
-
-    if (spectrogramSettings) {
-      spectrogramSettings.textContent =
-        `Sampling rate: ${sampleRate / 1000}kHz`;
-    }
 
     if (typeof onAfterLoad === 'function') {
       onAfterLoad();


### PR DESCRIPTION
## Summary
- update brightness control to refresh color bar while sliding
- avoid overwriting spectrogram settings text during file loads
- redraw color bar and settings text after loading files

## Testing
- `node -e "require('./modules/fileLoader.js')"`
- `node -e "require('./modules/dragDropLoader.js')"`
- `node -e "require('./modules/brightnessControl.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68710c322928832a9f75bbc6222b737e