### PR TITLE
Add color map dropdown and brightness transformation

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ initScrollSync,
 import { initZoomControls } from './modules/zoomControl.js';
 import { initFileLoader, getWavSampleRate } from './modules/fileLoader.js';
 import { initBrightnessControl } from './modules/brightnessControl.js';
+import { COLOR_MAPS, COLOR_MAP_ITEMS, getColorMap } from './modules/colormaps.js';
 import { initFrequencyHover } from './modules/frequencyHover.js';
 import { cropWavBlob } from './modules/cropAudio.js';
 import { drawTimeAxis, drawFrequencyGrid } from './modules/axisRenderer.js';
@@ -326,13 +327,14 @@ updateExpandBackBtn();
 }
 });
 
-initBrightnessControl({
-brightnessSliderId: 'brightnessSlider',
-gainSliderId: 'gainSlider',
-brightnessValId: 'brightnessVal',
-gainValId: 'gainVal',
-resetBtnId: 'resetButton',
-onColorMapUpdated: (colorMap) => {
+const brightnessControl = initBrightnessControl({
+  brightnessSliderId: 'brightnessSlider',
+  gainSliderId: 'gainSlider',
+  brightnessValId: 'brightnessVal',
+  gainValId: 'gainVal',
+  resetBtnId: 'resetButton',
+  baseColorMap: COLOR_MAPS.grayscale,
+  onColorMapUpdated: (colorMap) => {
 freqHoverControl?.hideHover();        
 replacePlugin(
 colorMap,
@@ -427,11 +429,16 @@ const sampleRateDropdown = initDropdown('sampleRateInput', [
 sampleRateDropdown.select(0);
 
 const fftSizeDropdown = initDropdown('fftSizeInput', [
-{ label: '512', value: 512 },
-{ label: '1024', value: 1024 },
-{ label: '2048', value: 2048 },
+  { label: '512', value: 512 },
+  { label: '1024', value: 1024 },
+  { label: '2048', value: 2048 },
 ], { onChange: (item) => handleFftSize(item.value) });
 fftSizeDropdown.select(1);
+
+const colorMapDropdown = initDropdown('colorMapInput', COLOR_MAP_ITEMS, {
+  onChange: (item) => handleColorMapChange(item.value)
+});
+colorMapDropdown.select(0);
 
 const overlapInput = document.getElementById('overlapInput');
 overlapInput.value = '';
@@ -488,6 +495,7 @@ function drawColorBar(colorMap) {
   const ctx = canvas.getContext('2d');
   const width = canvas.width;
   const height = canvas.height;
+  ctx.clearRect(0, 0, width, height);
   const step = width / colorMap.length;
   for (let i = 0; i < colorMap.length; i++) {
     const [r, g, b, a] = colorMap[i];
@@ -537,7 +545,12 @@ freqHoverControl?.refreshHover();
 },
 currentFftSize
 );
-updateSpectrogramSettingsText();
+  updateSpectrogramSettingsText();
+}
+
+function handleColorMapChange(name) {
+  const map = getColorMap(name);
+  brightnessControl.setBaseColorMap(map);
 }
 
 function handleOverlapChange() {

--- a/modules/brightnessControl.js
+++ b/modules/brightnessControl.js
@@ -6,6 +6,7 @@ export function initBrightnessControl({
   brightnessValId,
   gainValId,
   resetBtnId,
+  baseColorMap = [],
   defaultBrightness = 0,
   defaultGain = 2,
   onColorMapUpdated,
@@ -24,6 +25,8 @@ export function initBrightnessControl({
     gainVal.textContent = gain.toFixed(2);
   }
 
+  let baseMap = baseColorMap.slice();
+
   // 👉 真正重新生成 colorMap 並觸發外部 callback
   function updateColorMap() {
     const brightness = parseFloat(brightnessSlider.value);
@@ -33,11 +36,11 @@ export function initBrightnessControl({
     brightnessVal.textContent = brightness.toFixed(2);
     gainVal.textContent = gain.toFixed(2);
 
-    const colorMap = Array.from({ length: 256 }, (_, i) => {
-      const t = Math.pow(i / 255, gain);
-      let v = 1 - t + brightness;
-      v = Math.max(0, Math.min(1, v));
-      return [v, v, v, 1];
+    const colorMap = baseMap.map(([r, g, b, a]) => {
+      const nr = Math.max(0, Math.min(1, r * gain + brightness));
+      const ng = Math.max(0, Math.min(1, g * gain + brightness));
+      const nb = Math.max(0, Math.min(1, b * gain + brightness));
+      return [nr, ng, nb, a];
     });
 
     if (typeof onColorMapUpdated === 'function') {
@@ -62,4 +65,11 @@ export function initBrightnessControl({
 
   // 初次初始化
   updateColorMap();
+
+  return {
+    setBaseColorMap(map) {
+      baseMap = map.slice();
+      updateColorMap();
+    },
+  };
 }

--- a/modules/colormaps.js
+++ b/modules/colormaps.js
@@ -1,0 +1,74 @@
+// modules/colormaps.js
+// Provides predefined color maps for the spectrogram viewer.
+
+function generateGrayscale() {
+  const arr = [];
+  for (let i = 0; i < 256; i++) {
+    const v = i / 255;
+    arr.push([v, v, v, 1]);
+  }
+  return arr;
+}
+
+function interpolateStops(stops) {
+  const result = [];
+  const n = stops.length - 1;
+  for (let i = 0; i < 256; i++) {
+    const t = i / 255;
+    const seg = Math.min(n - 1, Math.floor(t * n));
+    const localT = (t - seg / n) * n;
+    const [r1, g1, b1] = stops[seg];
+    const [r2, g2, b2] = stops[seg + 1];
+    const r = r1 + (r2 - r1) * localT;
+    const g = g1 + (g2 - g1) * localT;
+    const b = b1 + (b2 - b1) * localT;
+    result.push([r, g, b, 1]);
+  }
+  return result;
+}
+
+function generateViridis() {
+  const stops = [
+    [68 / 255, 1 / 255, 84 / 255],    // #440154
+    [59 / 255, 82 / 255, 139 / 255],  // #3b528b
+    [33 / 255, 145 / 255, 140 / 255], // #21908c
+    [94 / 255, 201 / 255, 98 / 255],  // #5ec962
+    [253 / 255, 231 / 255, 37 / 255]  // #fde725
+  ];
+  return interpolateStops(stops);
+}
+
+function generateRGB() {
+  const arr = [];
+  for (let i = 0; i < 256; i++) {
+    const t = i / 255;
+    let r = 0, g = 0, b = 0;
+    if (t < 0.5) {
+      const u = t * 2;
+      r = 1 - u;
+      g = u;
+    } else {
+      const u = (t - 0.5) * 2;
+      g = 1 - u;
+      b = u;
+    }
+    arr.push([r, g, b, 1]);
+  }
+  return arr;
+}
+
+export const COLOR_MAPS = {
+  grayscale: generateGrayscale(),
+  viridis: generateViridis(),
+  rgb: generateRGB(),
+};
+
+export const COLOR_MAP_ITEMS = [
+  { label: 'Grayscale', value: 'grayscale' },
+  { label: 'Viridis', value: 'viridis' },
+  { label: 'Red, Green, Blue', value: 'rgb' },
+];
+
+export function getColorMap(name) {
+  return COLOR_MAPS[name] || COLOR_MAPS.grayscale;
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -93,6 +93,7 @@
           <input type="number" id="freqMaxInput" class="freq-input" title="Maximum frequency (kHz)" value="128" min="1" max="192" step="1">
         </label>
         <button id="applyFreqRangeBtn" title="Apply frequency range" class="toolbar-button"><i class="fa-solid fa-check"></i></button>
+        <button id="colorMapInput" class="dropdown-button" title="Color Map">Grayscale</button>
         <i class="fa-solid fa-sun"></i>
         <input type="range" id="brightnessSlider" min="-0.2" max="0.2" step="0.01" value="0" title="Brightness">
         <span class="slider-value" id="brightnessVal">0</span>


### PR DESCRIPTION
## Summary
- define grayscale, viridis and RGB colormaps
- support changing base colormap in brightness control
- add a Color Map dropdown in the toolbar
- update spectrogram when the colormap changes
- clear color bar before drawing

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68712222ece8832aa273221eea143f0f