### PR TITLE
Fix highlight toggle and update range

### DIFF
--- a/main.js
+++ b/main.js
@@ -80,6 +80,9 @@ sampleRate: currentSampleRate,
 const overlay = document.getElementById('drop-overlay');
 const loadingOverlay = document.getElementById('loading-overlay');
 const uploadOverlay = document.getElementById('upload-overlay');
+const maxFreqBtn = document.getElementById('maxFreqToggleBtn');
+let highlightMaxFreq = false;
+let currentBaseColorMap = [];
 
 function showDropOverlay() {
 overlay.style.display = 'flex';
@@ -104,6 +107,29 @@ showDropOverlay();
 document.addEventListener('drop-overlay-show', showDropOverlay);
 document.addEventListener('drop-overlay-hide', hideDropOverlay);
 updateSpectrogramSettingsText();
+
+maxFreqBtn.addEventListener('click', () => {
+  highlightMaxFreq = !highlightMaxFreq;
+  maxFreqBtn.innerHTML = highlightMaxFreq ?
+    '<i class="fa-solid fa-eye-slash"></i>' :
+    '<i class="fa-solid fa-eye"></i>';
+  const finalMap = applyHighlight(currentBaseColorMap);
+  freqHoverControl?.hideHover();
+  replacePlugin(
+    finalMap,
+    spectrogramHeight,
+    currentFreqMin,
+    currentFreqMax,
+    getOverlapPercent(),
+    () => {
+      duration = getWavesurfer().getDuration();
+      zoomControl.applyZoom();
+      renderAxes();
+      freqHoverControl?.refreshHover();
+    }
+  );
+  drawColorBar(finalMap);
+});
 
 fileLoaderControl = initFileLoader({
 fileInputId: 'fileInput',
@@ -333,13 +359,15 @@ brightnessValId: 'brightnessVal',
 gainValId: 'gainVal',
 resetBtnId: 'resetButton',
 onColorMapUpdated: (colorMap) => {
-freqHoverControl?.hideHover();        
-replacePlugin(
-colorMap,
-spectrogramHeight,
-currentFreqMin,
-currentFreqMax,
-getOverlapPercent(),
+  freqHoverControl?.hideHover();
+  currentBaseColorMap = colorMap;
+  const finalMap = applyHighlight(colorMap);
+  replacePlugin(
+  finalMap,
+  spectrogramHeight,
+  currentFreqMin,
+  currentFreqMax,
+  getOverlapPercent(),
 () => {
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
@@ -347,7 +375,7 @@ renderAxes();
   freqHoverControl?.refreshHover();
   }
   );
-  drawColorBar(colorMap);
+  drawColorBar(finalMap);
   },
 });
 
@@ -494,6 +522,13 @@ function drawColorBar(colorMap) {
     ctx.fillStyle = `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
     ctx.fillRect(i * step, 0, step, height);
   }
+}
+
+function applyHighlight(map) {
+  if (!highlightMaxFreq) return map;
+  const count = Math.floor(map.length * 0.1);
+  const yellow = [1, 215 / 255, 0, 1];
+  return map.map((c, i) => (i >= map.length - count ? yellow : c));
 }
 
 function getOverlapPercent() {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -119,6 +119,7 @@
       <div id="whole-spectrogram">
       <div id="spectrogram-settings">
         <span id="spectrogram-settings-text"></span>
+        <button id="maxFreqToggleBtn" class="toolbar-button" title="Show maximum frequency"><i class="fa-solid fa-eye"></i></button>
         <canvas id="color-bar" width="600" height="20"></canvas>
       </div>
       <div class="viewer-row">

--- a/style.css
+++ b/style.css
@@ -502,7 +502,8 @@ input[type="file"]:hover {
   z-index: 100;
 }
 
-#tool-bar .toolbar-button {
+#tool-bar .toolbar-button,
+.toolbar-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -515,7 +516,7 @@ input[type="file"]:hover {
   transition: background-color 0.2s;
 }
 
-#tool-bar .toolbar-button:hover {
+.toolbar-button:hover {
   background-color: rgba(0, 0, 0, 0.05);
 }
 


### PR DESCRIPTION
## Summary
- store base color map for consistent updates
- reapply highlight when toggling the button instead of firing slider events
- highlight the darkest 10% of the colourmap

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68712ec1b188832aa2671977644b0142