### PR TITLE
Add dB display on hover

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -1,3 +1,5 @@
+import { getCurrentColorMap } from './wsManager.js';
+
 export function initFrequencyHover({
   viewerId,
   wrapperId = 'viewer-wrapper',
@@ -68,6 +70,33 @@ export function initFrequencyHover({
     const actualWidth = container.scrollWidth;
     const time = ((x + scrollLeft) / actualWidth) * getDuration();
 
+    let dbText = '';
+    try {
+      const canvas = document.getElementById('spectrogram-canvas');
+      const ctx = canvas?.getContext('2d');
+      const colorMap = getCurrentColorMap();
+      if (ctx && colorMap) {
+        const scaleX = canvas.width / actualWidth;
+        const scaleY = canvas.height / spectrogramHeight;
+        const pxData = ctx.getImageData(Math.floor((x + scrollLeft) * scaleX), Math.floor(y * scaleY), 1, 1).data;
+        const v = pxData[0] / 255;
+        let closest = 0;
+        let diff = Infinity;
+        for (let i = 0; i < colorMap.length; i++) {
+          const d = Math.abs(colorMap[i][0] - v);
+          if (d < diff) {
+            diff = d;
+            closest = i;
+          }
+        }
+        const val = closest / 255;
+        const db = val * 100;
+        dbText = `   ${db.toFixed(1)} dB`;
+      }
+    } catch (err) {
+      // ignore errors from getImageData
+    }
+
     hoverLine.style.top = `${y}px`;
     hoverLine.style.display = 'block';
 
@@ -89,7 +118,7 @@ export function initFrequencyHover({
     freqLabel.style.top = `${y}px`;
     freqLabel.style.left = labelLeft;
     freqLabel.style.display = 'block';
-    freqLabel.textContent = `${freq.toFixed(1)} kHz   ${(time * 1000).toFixed(1)} ms`;
+    freqLabel.textContent = `${freq.toFixed(1)} kHz   ${(time * 1000).toFixed(1)} ms${dbText}`;
   };
 
   viewer.addEventListener('mousemove', updateHoverDisplay, { passive: true });


### PR DESCRIPTION
## Summary
- show approximate dB value when hovering the spectrogram by reading the pixel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68713ac839ac832aae3b3a950dcf55d8