### PR TITLE
Replace contrast wording with gain

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -96,10 +96,10 @@
         <i class="fa-solid fa-sun"></i>
         <input type="range" id="brightnessSlider" min="-0.2" max="0.5" step="0.02" value="0" title="Brightness">
         <span class="slider-value" id="brightnessVal">0</span>
-        <i class="fa-solid fa-circle-half-stroke contrast-icon"></i>
-        <input type="range" id="gainSlider" min="0.5" max="4" step="0.1" value="2" title="Contrast">
+        <i class="fa-solid fa-circle-half-stroke gain-icon"></i>
+        <input type="range" id="gainSlider" min="0.5" max="4" step="0.1" value="2" title="Gain">
         <span class="slider-value" id="gainVal">2</span>
-        <button id="resetButton" title="Reset Brightness & Contrast to default" class="toolbar-button"><i class="fas fa-rotate-left"></i></button>
+        <button id="resetButton" title="Reset Brightness & Gain to default" class="toolbar-button"><i class="fas fa-rotate-left"></i></button>
         <div class="toolbar-divider"></div>                                                                                                                     
         <label class="slider-label">Line
           <label class="switch" title="Show 10kHz Lines">

--- a/style.css
+++ b/style.css
@@ -1305,7 +1305,7 @@ input.tag-button.editing {
   padding-right: 0;
 }
 
-.contrast-icon {
+.gain-icon {
   padding-left: 15px;
 }
 


### PR DESCRIPTION
## Summary
- rename CSS class `contrast-icon` to `gain-icon`
- update the UI labels in `sonoradar.html` to use gain terminology

## Testing
- `grep -Rin --exclude-dir=.git -i "contrast"`

------
https://chatgpt.com/codex/tasks/task_e_6871e2f80a9c832a9fb4920719f2e685