### PR TITLE
Add contrast control

### DIFF
--- a/main.js
+++ b/main.js
@@ -329,8 +329,10 @@ updateExpandBackBtn();
 initBrightnessControl({
 brightnessSliderId: 'brightnessSlider',
 gainSliderId: 'gainSlider',
+contrastSliderId: 'contrastSlider',
 brightnessValId: 'brightnessVal',
 gainValId: 'gainVal',
+contrastValId: 'contrastVal',
 resetBtnId: 'resetButton',
 onColorMapUpdated: (colorMap) => {
 freqHoverControl?.hideHover();        

--- a/modules/brightnessControl.js
+++ b/modules/brightnessControl.js
@@ -3,39 +3,49 @@
 export function initBrightnessControl({
   brightnessSliderId,
   gainSliderId,
+  contrastSliderId,
   brightnessValId,
   gainValId,
+  contrastValId,
   resetBtnId,
   defaultBrightness = 0,
   defaultGain = 2,
+  defaultContrast = 1,
   onColorMapUpdated,
 }) {
   const brightnessSlider = document.getElementById(brightnessSliderId);
   const gainSlider = document.getElementById(gainSliderId);
+  const contrastSlider = document.getElementById(contrastSliderId);
   const brightnessVal = document.getElementById(brightnessValId);
   const gainVal = document.getElementById(gainValId);
+  const contrastVal = document.getElementById(contrastValId);
   const resetBtn = document.getElementById(resetBtnId);
 
   // 👉 滑動中只更新顯示文字，不更新圖
   function updateSliderValues() {
     const brightness = parseFloat(brightnessSlider.value);
     const gain = parseFloat(gainSlider.value);
+    const contrast = parseFloat(contrastSlider.value);
     brightnessVal.textContent = brightness.toFixed(2);
     gainVal.textContent = gain.toFixed(2);
+    contrastVal.textContent = contrast.toFixed(2);
   }
 
   // 👉 真正重新生成 colorMap 並觸發外部 callback
   function updateColorMap() {
     const brightness = parseFloat(brightnessSlider.value);
     const gain = parseFloat(gainSlider.value);
+    const contrast = parseFloat(contrastSlider.value);
 
     // 同步更新 UI
     brightnessVal.textContent = brightness.toFixed(2);
     gainVal.textContent = gain.toFixed(2);
+    contrastVal.textContent = contrast.toFixed(2);
 
     const colorMap = Array.from({ length: 256 }, (_, i) => {
       const t = Math.pow(i / 255, gain);
       let v = 1 - t + brightness;
+      v = (v - 0.5) * contrast + 0.5;
       v = Math.max(0, Math.min(1, v));
       return [v, v, v, 1];
     });
@@ -53,10 +63,12 @@ export function initBrightnessControl({
 
   brightnessSlider.addEventListener('input', handleInput);
   gainSlider.addEventListener('input', handleInput);
+  contrastSlider.addEventListener('input', handleInput);
 
   resetBtn.addEventListener('click', () => {
     brightnessSlider.value = defaultBrightness;
     gainSlider.value = defaultGain;
+    contrastSlider.value = defaultContrast;
     updateColorMap();
   });
 

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -93,13 +93,16 @@
           <input type="number" id="freqMaxInput" class="freq-input" title="Maximum frequency (kHz)" value="128" min="1" max="192" step="1">
         </label>
         <button id="applyFreqRangeBtn" title="Apply frequency range" class="toolbar-button"><i class="fa-solid fa-check"></i></button>
+        <i class="fa-solid fa-circle-half-stroke contrast-icon"></i>
+        <input type="range" id="contrastSlider" min="0.5" max="2" step="0.05" value="1" title="Contrast">
+        <span class="slider-value" id="contrastVal">1</span>
         <i class="fa-solid fa-sun brightness-icon"></i>
         <input type="range" id="brightnessSlider" min="-0.2" max="0.5" step="0.02" value="0" title="Brightness">
         <span class="slider-value" id="brightnessVal">0</span>
         <i class="fa-solid fa-plus-minus gain-icon"></i>
         <input type="range" id="gainSlider" min="0.5" max="4" step="0.1" value="2" title="Gain">
         <span class="slider-value" id="gainVal">2</span>
-        <button id="resetButton" title="Reset Brightness & Gain to default" class="toolbar-button"><i class="fas fa-rotate-left"></i></button>
+        <button id="resetButton" title="Reset Brightness, Contrast & Gain to default" class="toolbar-button"><i class="fas fa-rotate-left"></i></button>
         <div class="toolbar-divider"></div>                                                                                                                     
         <label class="slider-label">Line
           <label class="switch" title="Show 10kHz Lines">

--- a/style.css
+++ b/style.css
@@ -1306,7 +1306,8 @@ input.tag-button.editing {
 }
 
 .brightness-icon,
-.gain-icon {
+.gain-icon,
+.contrast-icon {
   padding-left: 10px;
   margin-right: -10px;
 }


### PR DESCRIPTION
## Summary
- add contrast slider UI and icon
- extend brightness control module to handle contrast
- connect contrast slider in main.js
- style new contrast icon

## Testing
- `node --check modules/brightnessControl.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_6871e86be514832a9828606193a7843b