### PR TITLE
Update slider events to delay spectrogram update

### DIFF
--- a/modules/brightnessControl.js
+++ b/modules/brightnessControl.js
@@ -55,15 +55,21 @@ export function initBrightnessControl({
     }
   }
 
-  // 事件綁定 - 在滑動時即時更新數值和顏色條
+  // 事件綁定 - 滑動時僅更新文字，放開後才更新圖表
   function handleInput() {
     updateSliderValues();
+  }
+
+  function handleChange() {
     updateColorMap();
   }
 
   brightnessSlider.addEventListener('input', handleInput);
   gainSlider.addEventListener('input', handleInput);
   contrastSlider.addEventListener('input', handleInput);
+  brightnessSlider.addEventListener('change', handleChange);
+  gainSlider.addEventListener('change', handleChange);
+  contrastSlider.addEventListener('change', handleChange);
 
   resetBtn.addEventListener('click', () => {
     brightnessSlider.value = defaultBrightness;


### PR DESCRIPTION
## Summary
- update brightness slider events to apply color changes only after releasing the slider

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68724e752430832aa79060af78deeacd