### PR TITLE
Use flex rows for toolbar

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -77,6 +77,7 @@
       </div>
       <!-- Tool Bar -->    
       <div id="tool-bar">
+        <div class="toolbar-row">
         <label class="slider-label">Fs
           <button id="sampleRateInput" class="dropdown-button" title="Sampling rate (kHz)">256</button>
         </label>
@@ -92,8 +93,9 @@
           <input type="number" id="freqMinInput" class="freq-input" title="Minimun frequency (kHz)" value="10" min="0" max="192" step="1"> -
           <input type="number" id="freqMaxInput" class="freq-input" title="Maximum frequency (kHz)" value="128" min="1" max="192" step="1">
         </label>
-        <button id="applyFreqRangeBtn" title="Apply frequency range" class="toolbar-button"><i class="fa-solid fa-check"></i></button>
-        <div class="toolbar-break"></div>
+          <button id="applyFreqRangeBtn" title="Apply frequency range" class="toolbar-button"><i class="fa-solid fa-check"></i></button>
+        </div>
+        <div class="toolbar-row">
         <i class="fa-solid fa-circle-half-stroke contrast-icon"></i>
         <input type="range" id="contrastSlider" min="0.5" max="2" step="0.05" value="1.2" title="Contrast">
         <span class="slider-value" id="contrastVal">1</span>

--- a/style.css
+++ b/style.css
@@ -479,10 +479,10 @@ input[type="file"]:hover {
   top: calc(100% + 30px);
   transform: translateX(-50%) scale(0.9);
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
-  gap: 12px;
+  gap: 6px;
   padding: 8px 12px;
   width: 660px;
   background-color: #fff;
@@ -526,9 +526,12 @@ input[type="file"]:hover {
   background-color: #ddd;
   margin: 0 0 0 -4px;
 }
-#tool-bar .toolbar-break {
-  flex-basis: 100%;
-  height: 0;
+#tool-bar .toolbar-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
 }
 
 /* === Sidebar Button === */


### PR DESCRIPTION
## Summary
- wrap toolbar items in flex rows instead of using `.toolbar-break`
- reduce vertical spacing between rows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687288ff0e24832a9094bdca7db52274