### PR TITLE
Fix map markers update after trash clear

### DIFF
--- a/main.js
+++ b/main.js
@@ -666,6 +666,7 @@ fileLoaderControl.loadFileAtIndex(idx);
 }
 }
 tagControl.updateTagButtonStates();
+document.dispatchEvent(new Event('file-list-changed'));
 }
 });
 

--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -861,6 +861,7 @@ export function initMapPopup({
   }
   document.addEventListener('file-loaded', updateMap);
   document.addEventListener('file-list-cleared', () => refreshMarkers());
+  document.addEventListener('file-list-changed', () => refreshMarkers());
   document.addEventListener('file-icon-toggled', () => refreshMarkers());
 }
 


### PR DESCRIPTION
## Summary
- refresh map markers when trash files are deleted
- listen for `file-list-changed` events in map popup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872942c626c832aad6e7386049a8e8f