### PR TITLE
Fix map marker style for mixed trash flags

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -374,9 +374,11 @@ export function initMapPopup({
       const first = group[0];
       const { lat, lon } = first;
       const isCurrent = group.some(g => g.idx === curIdx);
-      const hasTrash = group.some(g => getFileIconState(g.idx).trash);
-      let cls = isCurrent ? 'map-marker-current' : 'map-marker-other';
-      if (!isCurrent && hasTrash) {
+      const allTrash = group.every(g => getFileIconState(g.idx).trash);
+      let cls = 'map-marker-other';
+      if (isCurrent) {
+        cls = 'map-marker-current';
+      } else if (allTrash) {
         cls = 'map-marker-trash';
       }
       const icon = L.divIcon({


### PR DESCRIPTION
## Summary
- resolve issue with markers containing both trashed and non-trashed WAV files
- assign `.map-marker-trash` only when **all** WAV files are trashed

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687297a1f6d4832aa71251575008c1dd