### PR TITLE
Fix popup resize interactions

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -10,6 +10,7 @@ export function initMapPopup({
   const btn = document.getElementById(buttonId);
   const popup = document.getElementById(popupId);
   const mapDiv = document.getElementById(mapId);
+  const viewer = document.getElementById('viewer-container');
   const dragBar = popup.querySelector('.popup-drag-bar');
   const closeBtn = popup.querySelector('.popup-close-btn');
   if (!btn || !popup || !mapDiv) return;
@@ -743,16 +744,37 @@ export function initMapPopup({
       offsetX = e.clientX - popup.offsetLeft;
       offsetY = e.clientY - popup.offsetTop;
       map?.dragging.disable();
+      if (viewer) {
+        viewer.style.pointerEvents = 'none';
+        viewer.classList.remove('hide-cursor');
+      }
       e.preventDefault();
       e.stopPropagation();
     });
   }
 
   popup.addEventListener('mousemove', (e) => {
-    if (dragging || resizing) return;
+    if (dragging || resizing) {
+      e.stopPropagation();
+      return;
+    }
     const state = getEdgeState(e.clientX, e.clientY);
     const cursor = edgeCursor(state) || 'default';
     popup.style.cursor = cursor;
+    if (cursor !== 'default') {
+      mapDiv.style.cursor = cursor;
+      document.body.style.cursor = cursor;
+      if (viewer) {
+        viewer.style.pointerEvents = 'none';
+        viewer.classList.remove('hide-cursor');
+      }
+      e.stopPropagation();
+    } else {
+      mapDiv.style.cursor = '';
+      document.body.style.cursor = '';
+      if (viewer) viewer.style.pointerEvents = '';
+      updateCursor();
+    }
   });
 
   popup.addEventListener('mousedown', (e) => {
@@ -766,7 +788,12 @@ export function initMapPopup({
       resizeBottom = state.onBottom;
       const cursor = edgeCursor(state) || 'default';
       popup.style.cursor = cursor;
+      mapDiv.style.cursor = cursor;
       document.body.style.cursor = cursor;
+      if (viewer) {
+        viewer.style.pointerEvents = 'none';
+        viewer.classList.remove('hide-cursor');
+      }
       startX = e.clientX;
       startY = e.clientY;
       startWidth = popup.offsetWidth;
@@ -780,14 +807,36 @@ export function initMapPopup({
   });
 
   document.addEventListener('mousemove', (e) => {
-    if (dragging || resizing || popup.style.display !== 'block') return;
+    if (popup.style.display !== 'block') return;
+    if (dragging || resizing) {
+      e.stopPropagation();
+      return;
+    }
     const state = getEdgeState(e.clientX, e.clientY);
     const cursor = edgeCursor(state);
-    document.body.style.cursor = cursor || '';
-  });
+    if (cursor) {
+      document.body.style.cursor = cursor;
+      mapDiv.style.cursor = cursor;
+      if (viewer) {
+        viewer.style.pointerEvents = 'none';
+        viewer.classList.remove('hide-cursor');
+      }
+      e.stopPropagation();
+    } else {
+      document.body.style.cursor = '';
+      mapDiv.style.cursor = '';
+      if (viewer) viewer.style.pointerEvents = '';
+      updateCursor();
+    }
+  }, true);
 
   document.addEventListener('mousedown', (e) => {
-    if (dragging || resizing || popup.style.display !== 'block') return;
+    if (popup.style.display !== 'block') return;
+    if (dragging || resizing) {
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
     if (e.target === dragBar || dragBar.contains(e.target)) return;
     const state = getEdgeState(e.clientX, e.clientY);
     if (state.onLeft || state.onRight || state.onTop || state.onBottom) {
@@ -797,7 +846,13 @@ export function initMapPopup({
       resizeTop = state.onTop;
       resizeBottom = state.onBottom;
       const cursor = edgeCursor(state) || 'default';
+      popup.style.cursor = cursor;
+      mapDiv.style.cursor = cursor;
       document.body.style.cursor = cursor;
+      if (viewer) {
+        viewer.style.pointerEvents = 'none';
+        viewer.classList.remove('hide-cursor');
+      }
       startX = e.clientX;
       startY = e.clientY;
       startWidth = popup.offsetWidth;
@@ -808,18 +863,21 @@ export function initMapPopup({
       e.preventDefault();
       e.stopPropagation();
     }
-  });
+  }, true);
 
   window.addEventListener('mousemove', (e) => {
     if (dragging) {
       popup.style.left = `${e.clientX - offsetX}px`;
       popup.style.top = `${e.clientY - offsetY}px`;
+      e.stopPropagation();
       return;
     }
     if (resizing) {
       const dx = e.clientX - startX;
       const dy = e.clientY - startY;
-      document.body.style.cursor = document.body.style.cursor || popup.style.cursor;
+      mapDiv.style.cursor = popup.style.cursor;
+      document.body.style.cursor = popup.style.cursor;
+      if (viewer) viewer.style.pointerEvents = 'none';
       if (resizeRight) {
         popupWidth = Math.max(200, startWidth + dx);
         popup.style.width = `${popupWidth}px`;
@@ -838,13 +896,16 @@ export function initMapPopup({
         popup.style.height = `${popupHeight}px`;
         popup.style.top = `${startTop + dy}px`;
       }
+      e.stopPropagation();
     }
-  });
+  }, true);
 
-  window.addEventListener('mouseup', () => {
+  window.addEventListener('mouseup', (e) => {
     if (dragging) {
       dragging = false;
       map?.dragging.enable();
+      if (viewer) viewer.style.pointerEvents = '';
+      e.stopPropagation();
     }
     if (resizing) {
       resizing = false;
@@ -854,8 +915,12 @@ export function initMapPopup({
       map?.invalidateSize();
       document.body.style.cursor = '';
       popup.style.cursor = '';
+      mapDiv.style.cursor = '';
+      if (viewer) viewer.style.pointerEvents = '';
+      updateCursor();
+      e.stopPropagation();
     }
-  });
+  }, true);
 
   btn.addEventListener('click', togglePopup);
   if (closeBtn) {


### PR DESCRIPTION
## Summary
- prevent spectrogram selection when resizing map popup
- keep resize cursors visible by disabling viewer pointer events

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6873571f9890832a995141bc9fb45814