### PR TITLE
Fix popup resize interactions

### DIFF
--- a/main.js
+++ b/main.js
@@ -681,6 +681,9 @@ document.body.classList.toggle('settings-open', isOpen);
 initExportCsv();
 initTrashProgram();
 initMapPopup();
+document.addEventListener('hide-spectrogram-hover', () => {
+  freqHoverControl?.hideHover();
+});
 document.addEventListener('map-file-selected', (e) => {
 const idx = e.detail?.index;
 if (typeof idx === 'number') {

--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -10,6 +10,9 @@ export function initMapPopup({
   const btn = document.getElementById(buttonId);
   const popup = document.getElementById(popupId);
   const mapDiv = document.getElementById(mapId);
+  const viewer = document.getElementById('viewer-container');
+  const controlBar = document.getElementById('control-bar');
+  const sidebar = document.getElementById('sidebar');
   const dragBar = popup.querySelector('.popup-drag-bar');
   const closeBtn = popup.querySelector('.popup-close-btn');
   if (!btn || !popup || !mapDiv) return;
@@ -737,22 +740,54 @@ export function initMapPopup({
   let startLeft = 0;
   let startTop = 0;
 
+  function disableUiPointerEvents() {
+    if (viewer) {
+      viewer.style.pointerEvents = 'none';
+      viewer.classList.remove('hide-cursor');
+    }
+    if (controlBar) controlBar.style.pointerEvents = 'none';
+    if (sidebar) sidebar.style.pointerEvents = 'none';
+  }
+
+  function enableUiPointerEvents() {
+    if (viewer) viewer.style.pointerEvents = '';
+    if (controlBar) controlBar.style.pointerEvents = '';
+    if (sidebar) sidebar.style.pointerEvents = '';
+  }
+
   if (dragBar) {
     dragBar.addEventListener('mousedown', (e) => {
       dragging = true;
       offsetX = e.clientX - popup.offsetLeft;
       offsetY = e.clientY - popup.offsetTop;
       map?.dragging.disable();
+      disableUiPointerEvents();
+      document.dispatchEvent(new Event('hide-spectrogram-hover'));
       e.preventDefault();
       e.stopPropagation();
     });
   }
 
   popup.addEventListener('mousemove', (e) => {
-    if (dragging || resizing) return;
+    if (dragging || resizing) {
+      e.stopPropagation();
+      return;
+    }
     const state = getEdgeState(e.clientX, e.clientY);
     const cursor = edgeCursor(state) || 'default';
     popup.style.cursor = cursor;
+    if (cursor !== 'default') {
+      mapDiv.style.cursor = cursor;
+      document.body.style.cursor = cursor;
+      disableUiPointerEvents();
+      document.dispatchEvent(new Event('hide-spectrogram-hover'));
+      e.stopPropagation();
+    } else {
+      mapDiv.style.cursor = '';
+      document.body.style.cursor = '';
+      enableUiPointerEvents();
+      updateCursor();
+    }
   });
 
   popup.addEventListener('mousedown', (e) => {
@@ -766,7 +801,10 @@ export function initMapPopup({
       resizeBottom = state.onBottom;
       const cursor = edgeCursor(state) || 'default';
       popup.style.cursor = cursor;
+      mapDiv.style.cursor = cursor;
       document.body.style.cursor = cursor;
+      disableUiPointerEvents();
+      document.dispatchEvent(new Event('hide-spectrogram-hover'));
       startX = e.clientX;
       startY = e.clientY;
       startWidth = popup.offsetWidth;
@@ -780,14 +818,34 @@ export function initMapPopup({
   });
 
   document.addEventListener('mousemove', (e) => {
-    if (dragging || resizing || popup.style.display !== 'block') return;
+    if (popup.style.display !== 'block') return;
+    if (dragging || resizing) {
+      e.stopPropagation();
+      return;
+    }
     const state = getEdgeState(e.clientX, e.clientY);
     const cursor = edgeCursor(state);
-    document.body.style.cursor = cursor || '';
-  });
+    if (cursor) {
+      document.body.style.cursor = cursor;
+      mapDiv.style.cursor = cursor;
+      disableUiPointerEvents();
+      document.dispatchEvent(new Event('hide-spectrogram-hover'));
+      e.stopPropagation();
+    } else {
+      document.body.style.cursor = '';
+      mapDiv.style.cursor = '';
+      enableUiPointerEvents();
+      updateCursor();
+    }
+  }, true);
 
   document.addEventListener('mousedown', (e) => {
-    if (dragging || resizing || popup.style.display !== 'block') return;
+    if (popup.style.display !== 'block') return;
+    if (dragging || resizing) {
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
     if (e.target === dragBar || dragBar.contains(e.target)) return;
     const state = getEdgeState(e.clientX, e.clientY);
     if (state.onLeft || state.onRight || state.onTop || state.onBottom) {
@@ -797,7 +855,11 @@ export function initMapPopup({
       resizeTop = state.onTop;
       resizeBottom = state.onBottom;
       const cursor = edgeCursor(state) || 'default';
+      popup.style.cursor = cursor;
+      mapDiv.style.cursor = cursor;
       document.body.style.cursor = cursor;
+      disableUiPointerEvents();
+      document.dispatchEvent(new Event('hide-spectrogram-hover'));
       startX = e.clientX;
       startY = e.clientY;
       startWidth = popup.offsetWidth;
@@ -808,18 +870,22 @@ export function initMapPopup({
       e.preventDefault();
       e.stopPropagation();
     }
-  });
+  }, true);
 
   window.addEventListener('mousemove', (e) => {
     if (dragging) {
       popup.style.left = `${e.clientX - offsetX}px`;
       popup.style.top = `${e.clientY - offsetY}px`;
+      e.stopPropagation();
       return;
     }
     if (resizing) {
       const dx = e.clientX - startX;
       const dy = e.clientY - startY;
-      document.body.style.cursor = document.body.style.cursor || popup.style.cursor;
+      mapDiv.style.cursor = popup.style.cursor;
+      document.body.style.cursor = popup.style.cursor;
+      disableUiPointerEvents();
+      document.dispatchEvent(new Event('hide-spectrogram-hover'));
       if (resizeRight) {
         popupWidth = Math.max(200, startWidth + dx);
         popup.style.width = `${popupWidth}px`;
@@ -838,13 +904,16 @@ export function initMapPopup({
         popup.style.height = `${popupHeight}px`;
         popup.style.top = `${startTop + dy}px`;
       }
+      e.stopPropagation();
     }
-  });
+  }, true);
 
-  window.addEventListener('mouseup', () => {
+  window.addEventListener('mouseup', (e) => {
     if (dragging) {
       dragging = false;
       map?.dragging.enable();
+      enableUiPointerEvents();
+      e.stopPropagation();
     }
     if (resizing) {
       resizing = false;
@@ -854,8 +923,12 @@ export function initMapPopup({
       map?.invalidateSize();
       document.body.style.cursor = '';
       popup.style.cursor = '';
+      mapDiv.style.cursor = '';
+      enableUiPointerEvents();
+      updateCursor();
+      e.stopPropagation();
     }
-  });
+  }, true);
 
   btn.addEventListener('click', togglePopup);
   if (closeBtn) {


### PR DESCRIPTION
## Summary
- prevent spectrogram selection when resizing map popup
- keep resize cursors visible by disabling viewer pointer events
- hide hoverlines when the cursor moves onto resize handles
- disable UI pointer events from top/side bars while resizing

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6873571f9890832a995141bc9fb45814