### PR TITLE
Fix sidebar file click area

### DIFF
--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -144,8 +144,8 @@ export function initSidebar({ onFileSelected } = {}) {
       rightContainer.appendChild(noteInput);
 
       li.appendChild(rightContainer);
-  
-      li.addEventListener('click', () => {
+
+      left.addEventListener('click', () => {
         if (typeof onFileSelected === 'function') {
           onFileSelected(index);
         }

--- a/style.css
+++ b/style.css
@@ -943,7 +943,6 @@ input.tag-button.editing {
 /* === Sidebar Items === */
 .sidebar-item {
   padding: 3px 0;
-  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -956,6 +955,7 @@ input.tag-button.editing {
   flex-grow: 1;
   min-width: 0;
   min-height: 20px;
+  cursor: pointer;
 }
 
 .sidebar-file-icon {


### PR DESCRIPTION
## Summary
- restrict file selection handler to only the left section of each file row
- update styling so only the left section shows pointer cursor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873c21eb130832a9b5400a1079aa7ef