### PR TITLE
Add audio/spectrogram caching and preload

### DIFF
--- a/modules/cacheManager.js
+++ b/modules/cacheManager.js
@@ -1,0 +1,92 @@
+export const audioCache = new Map();
+export const imageCache = new Map();
+let memoryLimit = 100 * 1024 * 1024; // 100MB approx
+
+export function setMemoryLimit(bytes) {
+  memoryLimit = bytes;
+}
+
+export function clearCache() {
+  audioCache.clear();
+  imageCache.clear();
+}
+
+function estimateAudioSize(buf) {
+  if (!buf) return 0;
+  if (buf.byteLength) return buf.byteLength;
+  if (buf.length) return buf.length * 4;
+  if (buf.numberOfChannels) {
+    let size = 0;
+    for (let i = 0; i < buf.numberOfChannels; i++) {
+      size += buf.getChannelData(i).byteLength;
+    }
+    return size;
+  }
+  return 0;
+}
+
+function estimateCanvasSize(canvas) {
+  if (!canvas) return 0;
+  return canvas.width * canvas.height * 4;
+}
+
+export function getMemoryUsage() {
+  let size = 0;
+  for (const v of audioCache.values()) size += estimateAudioSize(v);
+  for (const c of imageCache.values()) size += estimateCanvasSize(c);
+  return size;
+}
+
+function ensureLimit() {
+  if (getMemoryUsage() > memoryLimit) {
+    clearCache();
+  }
+}
+
+export async function decodeAudio(file) {
+  const ctx = new (window.AudioContext || window.webkitAudioContext)();
+  const buf = await file.arrayBuffer();
+  return ctx.decodeAudioData(buf.slice(0));
+}
+
+export async function renderSpectrogram(buffer, fftSize = 1024, overlap = 0) {
+  const canvas = new OffscreenCanvas(1, 1);
+  const worker = new Worker('./spectrogramWorker.js', { type: 'module' });
+  return new Promise((resolve) => {
+    worker.onmessage = () => {
+      worker.terminate();
+      resolve(canvas);
+    };
+    worker.postMessage({ type: 'init', canvas, sampleRate: buffer.sampleRate }, [canvas]);
+    worker.postMessage({ type: 'render', buffer: buffer.getChannelData(0), sampleRate: buffer.sampleRate, fftSize, overlap });
+  });
+}
+
+export async function preloadFile(index, file, opts = {}) {
+  if (!file || audioCache.has(index)) return;
+  try {
+    const audio = await decodeAudio(file);
+    audioCache.set(index, audio);
+    ensureLimit();
+    const img = await renderSpectrogram(audio, opts.fftSize, opts.overlap);
+    imageCache.set(index, img);
+    ensureLimit();
+  } catch (err) {
+    console.warn('Preload failed', err);
+  }
+}
+
+export function preloadNeighbors(currentIndex, fileList, opts = {}) {
+  setTimeout(() => {
+    if (currentIndex > 0) preloadFile(currentIndex - 1, fileList[currentIndex - 1], opts);
+    if (currentIndex < fileList.length - 1) preloadFile(currentIndex + 1, fileList[currentIndex + 1], opts);
+  }, 0);
+}
+
+export function getAudioBuffer(index) {
+  return audioCache.get(index);
+}
+
+export function getSpectrogramImage(index) {
+  return imageCache.get(index);
+}

--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -3,6 +3,7 @@
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { getWavSampleRate, getWavDuration } from './fileLoader.js';
 import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
+import { preloadNeighbors, getAudioBuffer } from './cacheManager.js';
 import { showMessageBox } from './messageBox.js';
 import { importKmlFile } from './mapPopup.js';
 
@@ -61,7 +62,9 @@ export function initDragDropLoader({
   async function loadFile(file) {
     if (!file) return;
 
-    const detectedSampleRate = await getWavSampleRate(file);
+    const idx = getCurrentIndex();
+    const cachedAudio = getAudioBuffer(idx);
+    const detectedSampleRate = cachedAudio ? cachedAudio.sampleRate : await getWavSampleRate(file);
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
     }    
@@ -84,11 +87,18 @@ export function initDragDropLoader({
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }
 
-    const fileUrl = URL.createObjectURL(file);
-    if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
-    lastObjectUrl = fileUrl;
-
-    await wavesurfer.load(fileUrl);
+    if (cachedAudio) {
+      if (lastObjectUrl) {
+        URL.revokeObjectURL(lastObjectUrl);
+        lastObjectUrl = null;
+      }
+      await wavesurfer.loadDecodedBuffer(cachedAudio);
+    } else {
+      const fileUrl = URL.createObjectURL(file);
+      if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
+      lastObjectUrl = fileUrl;
+      await wavesurfer.load(fileUrl);
+    }
 
     if (typeof onPluginReplaced === 'function') {
       onPluginReplaced();
@@ -106,6 +116,7 @@ export function initDragDropLoader({
       onAfterLoad();
     }
     document.dispatchEvent(new Event('file-loaded'));
+    preloadNeighbors(getCurrentIndex(), getFileList());
   }
 
   let pendingKmlFile = null;

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -2,6 +2,7 @@
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
+import { preloadNeighbors, getAudioBuffer } from './cacheManager.js';
 import { showMessageBox } from './messageBox.js';
 
 export async function getWavSampleRate(file) {
@@ -109,7 +110,9 @@ export function initFileLoader({
 
   async function loadFile(file) {
     if (!file) return;
-    const detectedSampleRate = await getWavSampleRate(file);
+    const idx = getCurrentIndex();
+    const cachedAudio = getAudioBuffer(idx);
+    const detectedSampleRate = cachedAudio ? cachedAudio.sampleRate : await getWavSampleRate(file);
 
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
@@ -137,11 +140,18 @@ export function initFileLoader({
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }
 
-    const fileUrl = URL.createObjectURL(file);
-    if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
-    lastObjectUrl = fileUrl;
-
-    await wavesurfer.load(fileUrl);
+    if (cachedAudio) {
+      if (lastObjectUrl) {
+        URL.revokeObjectURL(lastObjectUrl);
+        lastObjectUrl = null;
+      }
+      await wavesurfer.loadDecodedBuffer(cachedAudio);
+    } else {
+      const fileUrl = URL.createObjectURL(file);
+      if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
+      lastObjectUrl = fileUrl;
+      await wavesurfer.load(fileUrl);
+    }
 
     if (typeof onPluginReplaced === 'function') {
       onPluginReplaced();
@@ -153,7 +163,9 @@ export function initFileLoader({
       onAfterLoad();
     }
     document.dispatchEvent(new Event('file-loaded'));
-    
+
+    preloadNeighbors(getCurrentIndex(), getFileList());
+
   }
 
   fileInput.addEventListener('change', async (event) => {

--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -1,5 +1,7 @@
 // modules/fileState.js
 
+import { clearCache } from './cacheManager.js';
+
 let fileList = [];
 let currentIndex = -1;
 let fileIcons = {}; // { index: { trash: bool, star: bool, question: bool } }
@@ -12,6 +14,7 @@ export function setFileList(list, index = 0) {
   fileIcons = {};
   fileNotes = {};
   fileMetadata = {};
+  clearCache();
 }
 
 export function addFilesToList(list, index = 0) {
@@ -68,6 +71,7 @@ export function clearFileList() {
   fileIcons = {};
   fileNotes = {};
   fileMetadata = {};
+  clearCache();
 }
 
 export function setFileNote(index, note) {


### PR DESCRIPTION
## Summary
- add `cacheManager` to preload audio data and spectrogram images
- clear cache when file lists change
- start preloading neighbouring files after a file loads
- use cached audio data if available when loading files

## Testing
- `npm test` *(fails: package.json missing)*
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687b51d8e104832a8de075225587e581