### PR TITLE
Add audio/spectrogram caching and preload

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ import { initTagControl } from './modules/tagControl.js';
 import { initDropdown } from './modules/dropdown.js';
 import { showMessageBox } from './modules/messageBox.js';
 import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
+import { getSpectrogramImage, preloadFile } from './modules/cacheManager.js';
 
 const spectrogramHeight = 800;
 let sidebarControl;
@@ -902,10 +903,18 @@ document.addEventListener("file-loaded", async () => {
   currentExpandBlob = null;
   updateExpandBackBtn();
   if (currentFile) {
-    const arrayBuf = await currentFile.arrayBuffer();
-    const ac = new (window.AudioContext || window.webkitAudioContext)();
-    const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));
-    specWorker.postMessage({ type: "render", buffer: audioBuf.getChannelData(0), sampleRate: audioBuf.sampleRate, fftSize: currentFftSize, overlap: getOverlapPercent() }, [audioBuf.getChannelData(0).buffer]);
+    const idx = getCurrentIndex();
+    const cachedImg = getSpectrogramImage(idx);
+    if (cachedImg) {
+      const bmp = cachedImg;
+      specWorker.postMessage({ type: "drawImage", image: bmp });
+    } else {
+      const arrayBuf = await currentFile.arrayBuffer();
+      const ac = new (window.AudioContext || window.webkitAudioContext)();
+      const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));
+      specWorker.postMessage({ type: "render", buffer: audioBuf.getChannelData(0), sampleRate: audioBuf.sampleRate, fftSize: currentFftSize, overlap: getOverlapPercent() }, [audioBuf.getChannelData(0).buffer]);
+      preloadFile(idx, currentFile, { audioCtx: ac, fftSize: currentFftSize, overlap: getOverlapPercent() });
+    }
   }
 });
 

--- a/modules/cacheManager.js
+++ b/modules/cacheManager.js
@@ -1,0 +1,135 @@
+// Use Maps to preserve insertion order for a simple LRU strategy
+export const audioCache = new Map();
+export const imageCache = new Map();
+let memoryLimit = 100 * 1024 * 1024; // 100MB approx
+
+export function setMemoryLimit(bytes) {
+  memoryLimit = bytes;
+}
+
+export function clearCache() {
+  audioCache.clear();
+  imageCache.clear();
+}
+
+function estimateAudioSize(buf) {
+  if (!buf) return 0;
+  if (buf.byteLength) return buf.byteLength;
+  if (buf.length) return buf.length * 4;
+  if (buf.numberOfChannels) {
+    let size = 0;
+    for (let i = 0; i < buf.numberOfChannels; i++) {
+      size += buf.getChannelData(i).byteLength;
+    }
+    return size;
+  }
+  return 0;
+}
+
+function estimateCanvasSize(img) {
+  if (!img) return 0;
+  const w = img.width || 0;
+  const h = img.height || 0;
+  return w * h * 4;
+}
+
+export function getMemoryUsage() {
+  let size = 0;
+  for (const v of audioCache.values()) size += estimateAudioSize(v);
+  for (const c of imageCache.values()) size += estimateCanvasSize(c);
+  return size;
+}
+
+function ensureLimit() {
+  let usage = getMemoryUsage();
+  if (usage <= memoryLimit) return;
+  // remove oldest entries until under the limit
+  const removeOldest = () => {
+    const aKey = audioCache.keys().next().value;
+    const iKey = imageCache.keys().next().value;
+    const aSize = aKey !== undefined ? estimateAudioSize(audioCache.get(aKey)) : 0;
+    const iSize = iKey !== undefined ? estimateCanvasSize(imageCache.get(iKey)) : 0;
+    if (aSize >= iSize && aKey !== undefined) {
+      audioCache.delete(aKey);
+    } else if (iKey !== undefined) {
+      imageCache.delete(iKey);
+    } else if (aKey !== undefined) {
+      audioCache.delete(aKey);
+    }
+  };
+  while (usage > memoryLimit && (audioCache.size || imageCache.size)) {
+    removeOldest();
+    usage = getMemoryUsage();
+  }
+}
+
+export async function decodeAudio(file, audioCtx = null) {
+  const ctx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
+  const buf = await file.arrayBuffer();
+  const decoded = await ctx.decodeAudioData(buf.slice(0));
+  if (!audioCtx) {
+    try { ctx.close(); } catch (err) { /* noop */ }
+  }
+  return decoded;
+}
+
+export async function renderSpectrogram(buffer, fftSize = 1024, overlap = 0) {
+  const worker = new Worker('./spectrogramWorker.js', { type: 'module' });
+  return new Promise((resolve) => {
+    worker.onmessage = (e) => {
+      if (e.data.type === 'rendered') {
+        const bmp = e.data.bitmap;
+        worker.terminate();
+        resolve(bmp);
+      }
+    };
+    worker.postMessage({
+      type: 'render',
+      buffer: buffer.getChannelData(0),
+      sampleRate: buffer.sampleRate,
+      fftSize,
+      overlap,
+      returnBitmap: true
+    }, [buffer.getChannelData(0).buffer]);
+  });
+}
+
+export async function preloadFile(index, file, opts = {}) {
+  if (!file || (audioCache.has(index) && imageCache.has(index))) return;
+  try {
+    const audio = await decodeAudio(file, opts.audioCtx);
+    audioCache.set(index, audio);
+    ensureLimit();
+    const img = await renderSpectrogram(audio, opts.fftSize, opts.overlap);
+    imageCache.set(index, img);
+    ensureLimit();
+  } catch (err) {
+    console.warn('Preload failed', err);
+  }
+}
+
+export function preloadNeighbors(currentIndex, fileList, opts = {}) {
+  setTimeout(() => {
+    if (currentIndex > 0) preloadFile(currentIndex - 1, fileList[currentIndex - 1], opts);
+    if (currentIndex < fileList.length - 1) preloadFile(currentIndex + 1, fileList[currentIndex + 1], opts);
+  }, 0);
+}
+
+export function getAudioBuffer(index) {
+  const buf = audioCache.get(index);
+  if (buf) {
+    // refresh entry for LRU
+    audioCache.delete(index);
+    audioCache.set(index, buf);
+  }
+  return buf;
+}
+
+export function getSpectrogramImage(index) {
+  const img = imageCache.get(index);
+  if (img) {
+    imageCache.delete(index);
+    imageCache.set(index, img);
+  }
+  return img;
+}

--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -3,6 +3,7 @@
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { getWavSampleRate, getWavDuration } from './fileLoader.js';
 import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
+import { preloadNeighbors, getAudioBuffer, preloadFile } from './cacheManager.js';
 import { showMessageBox } from './messageBox.js';
 import { importKmlFile } from './mapPopup.js';
 
@@ -61,7 +62,9 @@ export function initDragDropLoader({
   async function loadFile(file) {
     if (!file) return;
 
-    const detectedSampleRate = await getWavSampleRate(file);
+    const idx = getCurrentIndex();
+    const cachedAudio = getAudioBuffer(idx);
+    const detectedSampleRate = cachedAudio ? cachedAudio.sampleRate : await getWavSampleRate(file);
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
     }    
@@ -84,11 +87,18 @@ export function initDragDropLoader({
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }
 
-    const fileUrl = URL.createObjectURL(file);
-    if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
-    lastObjectUrl = fileUrl;
-
-    await wavesurfer.load(fileUrl);
+    if (cachedAudio) {
+      if (lastObjectUrl) {
+        URL.revokeObjectURL(lastObjectUrl);
+        lastObjectUrl = null;
+      }
+      await wavesurfer.loadDecodedBuffer(cachedAudio);
+    } else {
+      const fileUrl = URL.createObjectURL(file);
+      if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
+      lastObjectUrl = fileUrl;
+      await wavesurfer.load(fileUrl);
+    }
 
     if (typeof onPluginReplaced === 'function') {
       onPluginReplaced();
@@ -106,6 +116,8 @@ export function initDragDropLoader({
       onAfterLoad();
     }
     document.dispatchEvent(new Event('file-loaded'));
+    preloadFile(getCurrentIndex(), file, { audioCtx: wavesurfer.backend.ac });
+    preloadNeighbors(getCurrentIndex(), getFileList(), { audioCtx: wavesurfer.backend.ac });
   }
 
   let pendingKmlFile = null;

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -2,6 +2,7 @@
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
+import { preloadNeighbors, getAudioBuffer, preloadFile } from './cacheManager.js';
 import { showMessageBox } from './messageBox.js';
 
 export async function getWavSampleRate(file) {
@@ -109,7 +110,9 @@ export function initFileLoader({
 
   async function loadFile(file) {
     if (!file) return;
-    const detectedSampleRate = await getWavSampleRate(file);
+    const idx = getCurrentIndex();
+    const cachedAudio = getAudioBuffer(idx);
+    const detectedSampleRate = cachedAudio ? cachedAudio.sampleRate : await getWavSampleRate(file);
 
     if (typeof onBeforeLoad === 'function') {
       onBeforeLoad();
@@ -137,11 +140,18 @@ export function initFileLoader({
       guanoOutput.textContent = '(Error reading GUANO metadata)';
     }
 
-    const fileUrl = URL.createObjectURL(file);
-    if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
-    lastObjectUrl = fileUrl;
-
-    await wavesurfer.load(fileUrl);
+    if (cachedAudio) {
+      if (lastObjectUrl) {
+        URL.revokeObjectURL(lastObjectUrl);
+        lastObjectUrl = null;
+      }
+      await wavesurfer.loadDecodedBuffer(cachedAudio);
+    } else {
+      const fileUrl = URL.createObjectURL(file);
+      if (lastObjectUrl) URL.revokeObjectURL(lastObjectUrl);
+      lastObjectUrl = fileUrl;
+      await wavesurfer.load(fileUrl);
+    }
 
     if (typeof onPluginReplaced === 'function') {
       onPluginReplaced();
@@ -153,7 +163,11 @@ export function initFileLoader({
       onAfterLoad();
     }
     document.dispatchEvent(new Event('file-loaded'));
-    
+
+    preloadFile(getCurrentIndex(), file, { audioCtx: wavesurfer.backend.ac });
+
+    preloadNeighbors(getCurrentIndex(), getFileList(), { audioCtx: wavesurfer.backend.ac });
+
   }
 
   fileInput.addEventListener('change', async (event) => {

--- a/modules/fileState.js
+++ b/modules/fileState.js
@@ -1,5 +1,7 @@
 // modules/fileState.js
 
+import { clearCache } from './cacheManager.js';
+
 let fileList = [];
 let currentIndex = -1;
 let fileIcons = {}; // { index: { trash: bool, star: bool, question: bool } }
@@ -12,6 +14,7 @@ export function setFileList(list, index = 0) {
   fileIcons = {};
   fileNotes = {};
   fileMetadata = {};
+  clearCache();
 }
 
 export function addFilesToList(list, index = 0) {
@@ -68,6 +71,7 @@ export function clearFileList() {
   fileIcons = {};
   fileNotes = {};
   fileMetadata = {};
+  clearCache();
 }
 
 export function setFileNote(index, note) {

--- a/spectrogramWorker.js
+++ b/spectrogramWorker.js
@@ -1,14 +1,34 @@
 let canvas, ctx, sampleRate = 44100;
 
-self.onmessage = (e) => {
+self.onmessage = async (e) => {
   const { type } = e.data;
   if (type === 'init') {
     canvas = e.data.canvas;
     sampleRate = e.data.sampleRate || sampleRate;
     ctx = canvas.getContext('2d');
   } else if (type === 'render') {
+    if (!ctx) {
+      canvas = new OffscreenCanvas(1, 1);
+      ctx = canvas.getContext('2d');
+    }
+    const bmp = renderSpectrogram(
+      e.data.buffer,
+      e.data.sampleRate || sampleRate,
+      e.data.fftSize || 1024,
+      e.data.overlap || 0
+    );
+    if (e.data.returnBitmap) {
+      self.postMessage({ type: 'rendered', bitmap: bmp }, [bmp]);
+    } else {
+      self.postMessage({ type: 'rendered' });
+    }
+  } else if (type === 'drawImage') {
     if (!ctx) return;
-    renderSpectrogram(e.data.buffer, e.data.sampleRate || sampleRate, e.data.fftSize || 1024, e.data.overlap || 0);
+    const img = e.data.image;
+    canvas.width = img.width;
+    canvas.height = img.height;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(img, 0, 0);
   }
 };
 
@@ -41,7 +61,7 @@ function renderSpectrogram(signal, sr, fftSize, overlapPct) {
     }
   }
   ctx.putImageData(img, 0, 0);
-  self.postMessage({ type: 'rendered' });
+  return canvas.transferToImageBitmap();
 }
 
 function hannWindow(N) {


### PR DESCRIPTION
## Summary
- add `cacheManager` to preload audio data and spectrogram images
- clear cache when file lists change
- start preloading neighbouring files after a file loads
- use cached audio data if available when loading files
- ensure cached decoding uses the same audio context
- improve cache eviction using LRU
- use cached spectrogram images when loading files

## Testing
- `npm test` *(fails: command not found)*
- `true`


------
https://chatgpt.com/codex/tasks/task_e_687b51d8e104832a8de075225587e581