### PR TITLE
Add keyboard shortcuts for spectrogram

### DIFF
--- a/main.js
+++ b/main.js
@@ -862,6 +862,24 @@ initMapPopup();
 document.addEventListener('hide-spectrogram-hover', () => {
   freqHoverControl?.hideHover();
 });
+document.addEventListener('keydown', (e) => {
+if (!e.ctrlKey) return;
+if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
+switch (e.key.toLowerCase()) {
+case 'm':
+e.preventDefault();
+document.getElementById('mapBtn')?.click();
+break;
+case 's':
+e.preventDefault();
+settingBtn.click();
+break;
+case 'p':
+e.preventDefault();
+playPauseBtn.click();
+break;
+}
+});
 document.addEventListener('map-file-selected', (e) => {
 const idx = e.detail?.index;
 if (typeof idx === 'number') {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -68,11 +68,11 @@
         <button id="prevBtn" title="Previous file (↑)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (↓)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
         <button id="toggleTagModeBtn" title="Tag mode" class="sidebar-button"><i class="fa-solid fa-tags"></i></button>
-        <button id="playPauseBtn" title="Play" class="sidebar-button"><i class="fa-solid fa-play"></i></button>
+        <button id="playPauseBtn" title="Play/Pause (Ctrl+P)" class="sidebar-button"><i class="fa-solid fa-play"></i></button>
         <button id="stopBtn" title="Stop" class="sidebar-button"><i class="fa-solid fa-stop"></i></button>
         <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
-        <button id="mapBtn" title="Map" class="sidebar-button"><i class="fa-solid fa-map-location-dot"></i></button>
-        <button id="setting" title="Spectrogram setting" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
+        <button id="mapBtn" title="Map (Ctrl+M)" class="sidebar-button"><i class="fa-solid fa-map-location-dot"></i></button>
+        <button id="setting" title="Spectrogram setting (Ctrl+S)" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
         <button id="expandBackBtn" title="Back to previous session (Backspace)" class="sidebar-button">
           <i class="fa-solid fa-reply"></i>
         </button>


### PR DESCRIPTION
## Summary
- add global keyboard handler for Map, Settings, and Play/Pause buttons
- document shortcuts in button tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ba8fb5984832a8588258e449bb3b2