### PR TITLE
Disable hover actions over selection tools

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -33,6 +33,7 @@ export function initFrequencyHover({
   let isOverTooltip = false;
   let isResizing = false;
   let isDrawing = false;
+  let isOverBtnGroup = false;
   let startX = 0, startY = 0;
   let selectionRect = null;
   let lastClientX = null, lastClientY = null;
@@ -46,7 +47,7 @@ export function initFrequencyHover({
   const updateHoverDisplay = (e) => {
     lastClientX = e.clientX;
     lastClientY = e.clientY;    
-    if (suppressHover || isResizing) {
+    if (suppressHover || isResizing || isOverBtnGroup) {
       hideAll();
       return;
     }
@@ -195,7 +196,7 @@ export function initFrequencyHover({
 
   viewer.addEventListener('contextmenu', (e) => {
     if (!persistentLinesEnabled || disablePersistentLinesForScrollbar || isOverTooltip) return;
-    if (e.target.closest('.selection-expand-btn')) return;
+    if (e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) return;
     e.preventDefault();
     const rect = fixedOverlay.getBoundingClientRect();
     const y = e.clientY - rect.top;
@@ -256,6 +257,7 @@ export function initFrequencyHover({
           selections.splice(index, 1);
         }
         suppressHover = false;
+        isOverBtnGroup = false;
       });
       closeBtn.addEventListener('mousedown', (ev) => { ev.stopPropagation(); });
       closeBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
@@ -272,6 +274,10 @@ export function initFrequencyHover({
       });
       expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
       expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
+
+      btnGroup.addEventListener('mouseenter', () => { isOverBtnGroup = true; hideAll(); });
+      btnGroup.addEventListener('mouseleave', () => { isOverBtnGroup = false; });
+      btnGroup.addEventListener('mousedown', (ev) => { ev.stopPropagation(); });
 
       btnGroup.appendChild(closeBtn);
       btnGroup.appendChild(expandBtn);
@@ -342,8 +348,8 @@ export function initFrequencyHover({
   
     // 只負責顯示滑鼠 cursor
     rect.addEventListener('mousemove', (e) => {
-      if (isDrawing || resizing) return;
-      if (e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn')) {
+      if (isDrawing || resizing || isOverBtnGroup) return;
+      if (e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) {
         rect.style.cursor = 'default';
         return;
       }
@@ -374,7 +380,7 @@ export function initFrequencyHover({
     // mousedown 時一次性決定 edge
     rect.addEventListener('mousedown', (e) => {
       if (resizing) return;
-      if (e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn')) return;
+      if (e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) return;
       const rectBox = rect.getBoundingClientRect();
       const offsetX = e.clientX - rectBox.left;
       const offsetY = e.clientY - rectBox.top;
@@ -509,6 +515,7 @@ export function initFrequencyHover({
               selections.splice(index, 1);
             }
             suppressHover = false;
+            isOverBtnGroup = false;
           });
           closeBtn.addEventListener('mousedown', (ev) => { ev.stopPropagation(); });
           closeBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
@@ -525,6 +532,10 @@ export function initFrequencyHover({
           });
           expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
           expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
+
+          group.addEventListener('mouseenter', () => { isOverBtnGroup = true; hideAll(); });
+          group.addEventListener('mouseleave', () => { isOverBtnGroup = false; });
+          group.addEventListener('mousedown', (ev) => { ev.stopPropagation(); });
 
           group.appendChild(closeBtn);
           group.appendChild(expandBtn);


### PR DESCRIPTION
## Summary
- suppress hover line display and disable resize when the mouse is over the selection buttons
- ignore context-menu actions on selection button groups

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687bcf0c0e18832ab698d9c843e89258