### PR TITLE
Fix hover display when expanding selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -475,22 +475,23 @@ document.addEventListener('mouseup', () => {
 });
 
 viewer.addEventListener('expand-selection', async (e) => {
-const { startTime, endTime } = e.detail;
-if (endTime > startTime) {
-const base = currentExpandBlob || getCurrentFile();
-const blob = await cropWavBlob(base, startTime, endTime);
-if (blob) {
-expandHistory.push(base);
-await getWavesurfer().loadBlob(blob);
-currentExpandBlob = blob;
-selectionExpandMode = true;
-zoomControl.setZoomLevel(0);
-sampleRateBtn.disabled = true;
-renderAxes();
-freqHoverControl?.clearSelections();
-updateExpandBackBtn();
-}
-}
+  const { startTime, endTime } = e.detail;
+  if (endTime > startTime) {
+    const base = currentExpandBlob || getCurrentFile();
+    const blob = await cropWavBlob(base, startTime, endTime);
+    if (blob) {
+      expandHistory.push(base);
+      await getWavesurfer().loadBlob(blob);
+      currentExpandBlob = blob;
+      selectionExpandMode = true;
+      zoomControl.setZoomLevel(0);
+      sampleRateBtn.disabled = true;
+      renderAxes();
+      freqHoverControl?.hideHover();
+      freqHoverControl?.clearSelections();
+      updateExpandBackBtn();
+    }
+  }
 });
 
 initBrightnessControl({


### PR DESCRIPTION
## Summary
- keep hover indicators hidden during selection expand

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c3af913f0832abf0034af3ddb2965