### PR TITLE
Fix hover display timing on expand

### DIFF
--- a/main.js
+++ b/main.js
@@ -475,22 +475,24 @@ document.addEventListener('mouseup', () => {
 });
 
 viewer.addEventListener('expand-selection', async (e) => {
-const { startTime, endTime } = e.detail;
-if (endTime > startTime) {
-const base = currentExpandBlob || getCurrentFile();
-const blob = await cropWavBlob(base, startTime, endTime);
-if (blob) {
-expandHistory.push(base);
-await getWavesurfer().loadBlob(blob);
-currentExpandBlob = blob;
-selectionExpandMode = true;
-zoomControl.setZoomLevel(0);
-sampleRateBtn.disabled = true;
-renderAxes();
-freqHoverControl?.clearSelections();
-updateExpandBackBtn();
-}
-}
+  const { startTime, endTime } = e.detail;
+  if (endTime > startTime) {
+    freqHoverControl?.hideHover();
+    const base = currentExpandBlob || getCurrentFile();
+    const blob = await cropWavBlob(base, startTime, endTime);
+    if (blob) {
+      expandHistory.push(base);
+      await getWavesurfer().loadBlob(blob);
+      currentExpandBlob = blob;
+      selectionExpandMode = true;
+      zoomControl.setZoomLevel(0);
+      sampleRateBtn.disabled = true;
+      renderAxes();
+      freqHoverControl?.hideHover();
+      freqHoverControl?.clearSelections();
+      updateExpandBackBtn();
+    }
+  }
 });
 
 initBrightnessControl({

--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -276,9 +276,6 @@ export function initFrequencyHover({
         }));
         suppressHover = false;
         isOverBtnGroup = false;
-        if (lastClientX !== null && lastClientY !== null) {
-          updateHoverDisplay({ clientX: lastClientX, clientY: lastClientY });
-        }
       });
       expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
       expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
@@ -546,9 +543,6 @@ export function initFrequencyHover({
             }));
             suppressHover = false;
             isOverBtnGroup = false;
-            if (lastClientX !== null && lastClientY !== null) {
-              updateHoverDisplay({ clientX: lastClientX, clientY: lastClientY });
-            }
           });
           expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
           expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });


### PR DESCRIPTION
## Summary
- keep hover indicators hidden until new spectrogram is rendered after expanding a selection
- keep hover indicators visible immediately after closing a selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c3af913f0832abf0034af3ddb2965