### PR TITLE
Add fit-to-window button for selections

### DIFF
--- a/main.js
+++ b/main.js
@@ -495,6 +495,29 @@ viewer.addEventListener('expand-selection', async (e) => {
   }
 });
 
+viewer.addEventListener('fit-window-selection', async (e) => {
+  const { startTime, endTime, Flow, Fhigh } = e.detail;
+  if (endTime > startTime) {
+    freqHoverControl?.hideHover();
+    const base = currentExpandBlob || getCurrentFile();
+    const blob = await cropWavBlob(base, startTime, endTime);
+    if (blob) {
+      expandHistory.push(base);
+      await getWavesurfer().loadBlob(blob);
+      currentExpandBlob = blob;
+      selectionExpandMode = true;
+      zoomControl.setZoomLevel(0);
+      sampleRateBtn.disabled = true;
+      freqMinInput.value = Flow.toFixed(1);
+      freqMaxInput.value = Fhigh.toFixed(1);
+      updateFrequencyRange(Flow, Fhigh);
+      freqHoverControl?.hideHover();
+      freqHoverControl?.clearSelections();
+      updateExpandBackBtn();
+    }
+  }
+});
+
 initBrightnessControl({
 brightnessSliderId: 'brightnessSlider',
 gainSliderId: 'gainSlider',

--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -196,7 +196,7 @@ export function initFrequencyHover({
 
   viewer.addEventListener('contextmenu', (e) => {
     if (!persistentLinesEnabled || disablePersistentLinesForScrollbar || isOverTooltip) return;
-    if (e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) return;
+    if (e.target.closest('.selection-expand-btn') || e.target.closest('.selection-fit-btn') || e.target.closest('.selection-btn-group')) return;
     e.preventDefault();
     const rect = fixedOverlay.getBoundingClientRect();
     const y = e.clientY - rect.top;
@@ -311,6 +311,25 @@ export function initFrequencyHover({
     expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
     expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
 
+    const fitBtn = document.createElement('i');
+    fitBtn.className = 'fa-solid fa-up-right-and-down-left-from-center selection-fit-btn';
+    fitBtn.title = 'Fit to window';
+    fitBtn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      viewer.dispatchEvent(new CustomEvent('fit-window-selection', {
+        detail: {
+          startTime: sel.data.startTime,
+          endTime: sel.data.endTime,
+          Flow: sel.data.Flow,
+          Fhigh: sel.data.Fhigh,
+        }
+      }));
+      suppressHover = false;
+      isOverBtnGroup = false;
+    });
+    fitBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
+    fitBtn.addEventListener('mouseleave', () => { suppressHover = false; });
+
     group.addEventListener('mouseenter', () => {
       isOverBtnGroup = true;
       hideAll();
@@ -321,11 +340,13 @@ export function initFrequencyHover({
 
     group.appendChild(closeBtn);
     group.appendChild(expandBtn);
+    group.appendChild(fitBtn);
     sel.rect.appendChild(group);
 
     sel.btnGroup = group;
     sel.closeBtn = closeBtn;
     sel.expandBtn = expandBtn;
+    sel.fitBtn = fitBtn;
   }
 
   function enableResize(sel) {
@@ -337,7 +358,7 @@ export function initFrequencyHover({
     // 只負責顯示滑鼠 cursor
     rect.addEventListener('mousemove', (e) => {
       if (isDrawing || resizing) return;
-      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) {
+      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-fit-btn') || e.target.closest('.selection-btn-group')) {
         rect.style.cursor = 'default';
         return;
       }
@@ -368,7 +389,7 @@ export function initFrequencyHover({
     // mousedown 時一次性決定 edge
     rect.addEventListener('mousedown', (e) => {
       if (resizing) return;
-      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) return;
+      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-fit-btn') || e.target.closest('.selection-btn-group')) return;
       const rectBox = rect.getBoundingClientRect();
       const offsetX = e.clientX - rectBox.left;
       const offsetY = e.clientY - rectBox.top;


### PR DESCRIPTION
## Summary
- add a new button in each selection to crop audio and adjust frequency range
- listen for `fit-window-selection` events and update spectrogram frequency range
- ensure selection logic ignores the new button when resizing or using context menu

## Testing
- `node -c main.js`
- `node -c modules/frequencyHover.js`

------
https://chatgpt.com/codex/tasks/task_e_687c438282f0832a852b7e6e364634f3