### PR TITLE
Add fit-to-window button for selections

### DIFF
--- a/main.js
+++ b/main.js
@@ -481,13 +481,36 @@ viewer.addEventListener('expand-selection', async (e) => {
     const base = currentExpandBlob || getCurrentFile();
     const blob = await cropWavBlob(base, startTime, endTime);
     if (blob) {
-      expandHistory.push(base);
+      expandHistory.push({ src: base, freqMin: currentFreqMin, freqMax: currentFreqMax });
       await getWavesurfer().loadBlob(blob);
       currentExpandBlob = blob;
       selectionExpandMode = true;
       zoomControl.setZoomLevel(0);
       sampleRateBtn.disabled = true;
       renderAxes();
+      freqHoverControl?.hideHover();
+      freqHoverControl?.clearSelections();
+      updateExpandBackBtn();
+    }
+  }
+});
+
+viewer.addEventListener('fit-window-selection', async (e) => {
+  const { startTime, endTime, Flow, Fhigh } = e.detail;
+  if (endTime > startTime) {
+    freqHoverControl?.hideHover();
+    const base = currentExpandBlob || getCurrentFile();
+    const blob = await cropWavBlob(base, startTime, endTime);
+    if (blob) {
+      expandHistory.push({ src: base, freqMin: currentFreqMin, freqMax: currentFreqMax });
+      await getWavesurfer().loadBlob(blob);
+      currentExpandBlob = blob;
+      selectionExpandMode = true;
+      zoomControl.setZoomLevel(0);
+      sampleRateBtn.disabled = true;
+      freqMinInput.value = Flow.toFixed(1);
+      freqMaxInput.value = Fhigh.toFixed(1);
+      updateFrequencyRange(Flow, Fhigh);
       freqHoverControl?.hideHover();
       freqHoverControl?.clearSelections();
       updateExpandBackBtn();
@@ -890,35 +913,43 @@ fileLoaderControl.loadFileAtIndex(idx);
 });
 
 expandBackBtn.addEventListener('click', async () => {
-if (expandHistory.length === 0) return;
-const wasSingle = expandHistory.length === 1;
-const prev = expandHistory.pop();
+  if (expandHistory.length === 0) return;
+  const wasSingle = expandHistory.length === 1;
+  const prevState = expandHistory.pop();
+  const prev = prevState.src;
+  const prevMin = prevState.freqMin;
+  const prevMax = prevState.freqMax;
 
-if (prev && prev.name !== undefined) {
-if (wasSingle) {
-await getWavesurfer().loadBlob(prev);
-duration = getWavesurfer().getDuration();
-currentExpandBlob = null;
-selectionExpandMode = false;
-sampleRateBtn.disabled = false;
-zoomControl.setZoomLevel(0);
-renderAxes();
-freqHoverControl?.clearSelections();
-expandHistory = [];
-} else {
-currentExpandBlob = null;
-await fileLoaderControl.loadFileAtIndex(getCurrentIndex());
-}
-} else if (prev) {
-await getWavesurfer().loadBlob(prev);
-currentExpandBlob = prev;
-selectionExpandMode = true;
-zoomControl.setZoomLevel(0);
-sampleRateBtn.disabled = true;
-renderAxes();
-freqHoverControl?.clearSelections();
-}
-updateExpandBackBtn();
+  if (prev && prev.name !== undefined) {
+    if (wasSingle) {
+      await getWavesurfer().loadBlob(prev);
+      duration = getWavesurfer().getDuration();
+      currentExpandBlob = null;
+      selectionExpandMode = false;
+      sampleRateBtn.disabled = false;
+      zoomControl.setZoomLevel(0);
+      renderAxes();
+      freqHoverControl?.clearSelections();
+      expandHistory = [];
+    } else {
+      currentExpandBlob = null;
+      await fileLoaderControl.loadFileAtIndex(getCurrentIndex());
+    }
+  } else if (prev) {
+    await getWavesurfer().loadBlob(prev);
+    currentExpandBlob = prev;
+    selectionExpandMode = true;
+    zoomControl.setZoomLevel(0);
+    sampleRateBtn.disabled = true;
+    renderAxes();
+    freqHoverControl?.clearSelections();
+  }
+
+  freqMinInput.value = prevMin.toFixed(1);
+  freqMaxInput.value = prevMax.toFixed(1);
+  updateFrequencyRange(prevMin, prevMax);
+
+  updateExpandBackBtn();
 });
 
 document.addEventListener('keydown', (e) => {

--- a/modules/axisRenderer.js
+++ b/modules/axisRenderer.js
@@ -94,7 +94,7 @@ export function drawFrequencyGrid({
     const label = document.createElement('div');
     label.className = 'freq-label-static freq-axis-label';
     label.style.top = `${y - 1}px`;
-    label.textContent = `${f + offsetKHz}kHz`;
+    label.textContent = `${(f + offsetKHz).toFixed(1)}kHz`;
     labelContainer.appendChild(label);
   }
 

--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -196,7 +196,7 @@ export function initFrequencyHover({
 
   viewer.addEventListener('contextmenu', (e) => {
     if (!persistentLinesEnabled || disablePersistentLinesForScrollbar || isOverTooltip) return;
-    if (e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) return;
+    if (e.target.closest('.selection-expand-btn') || e.target.closest('.selection-fit-btn') || e.target.closest('.selection-btn-group')) return;
     e.preventDefault();
     const rect = fixedOverlay.getBoundingClientRect();
     const y = e.clientY - rect.top;
@@ -311,6 +311,25 @@ export function initFrequencyHover({
     expandBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
     expandBtn.addEventListener('mouseleave', () => { suppressHover = false; });
 
+    const fitBtn = document.createElement('i');
+    fitBtn.className = 'fa-solid fa-up-right-and-down-left-from-center selection-fit-btn';
+    fitBtn.title = 'Fit to window';
+    fitBtn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      viewer.dispatchEvent(new CustomEvent('fit-window-selection', {
+        detail: {
+          startTime: sel.data.startTime,
+          endTime: sel.data.endTime,
+          Flow: sel.data.Flow,
+          Fhigh: sel.data.Fhigh,
+        }
+      }));
+      suppressHover = false;
+      isOverBtnGroup = false;
+    });
+    fitBtn.addEventListener('mouseenter', () => { suppressHover = true; hideAll(); });
+    fitBtn.addEventListener('mouseleave', () => { suppressHover = false; });
+
     group.addEventListener('mouseenter', () => {
       isOverBtnGroup = true;
       hideAll();
@@ -321,11 +340,13 @@ export function initFrequencyHover({
 
     group.appendChild(closeBtn);
     group.appendChild(expandBtn);
+    group.appendChild(fitBtn);
     sel.rect.appendChild(group);
 
     sel.btnGroup = group;
     sel.closeBtn = closeBtn;
     sel.expandBtn = expandBtn;
+    sel.fitBtn = fitBtn;
   }
 
   function enableResize(sel) {
@@ -337,7 +358,7 @@ export function initFrequencyHover({
     // 只負責顯示滑鼠 cursor
     rect.addEventListener('mousemove', (e) => {
       if (isDrawing || resizing) return;
-      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) {
+      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-fit-btn') || e.target.closest('.selection-btn-group')) {
         rect.style.cursor = 'default';
         return;
       }
@@ -368,7 +389,7 @@ export function initFrequencyHover({
     // mousedown 時一次性決定 edge
     rect.addEventListener('mousedown', (e) => {
       if (resizing) return;
-      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-btn-group')) return;
+      if (isOverBtnGroup || e.target.closest('.selection-close-btn') || e.target.closest('.selection-expand-btn') || e.target.closest('.selection-fit-btn') || e.target.closest('.selection-btn-group')) return;
       const rectBox = rect.getBoundingClientRect();
       const offsetX = e.clientX - rectBox.left;
       const offsetY = e.clientY - rectBox.top;


### PR DESCRIPTION
## Summary
- add a new button in each selection to crop audio and adjust frequency range
- listen for `fit-window-selection` events and update spectrogram frequency range
- ensure selection logic ignores the new button when resizing or using context menu
- round frequency labels to one decimal
- restore previous frequency range when using the expand back button

## Testing
- `node -c main.js`
- `node -c modules/frequencyHover.js`
- `node -c modules/axisRenderer.js`


------
https://chatgpt.com/codex/tasks/task_e_687c438282f0832a852b7e6e364634f3