### PR TITLE
Fix frequency label formatting

### DIFF
--- a/modules/axisRenderer.js
+++ b/modules/axisRenderer.js
@@ -94,7 +94,8 @@ export function drawFrequencyGrid({
     const label = document.createElement('div');
     label.className = 'freq-label-static freq-axis-label';
     label.style.top = `${y - 1}px`;
-    label.textContent = `${(f + offsetKHz).toFixed(1)}kHz`;
+    const freqValue = f + offsetKHz;
+    label.textContent = Number(freqValue.toFixed(1)).toString();
     labelContainer.appendChild(label);
   }
 

--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -92,7 +92,8 @@ export function initFrequencyHover({
     freqLabel.style.top = `${y}px`;
     freqLabel.style.left = labelLeft;
     freqLabel.style.display = 'block';
-    freqLabel.textContent = `${freq.toFixed(1)} kHz   ${(time * 1000).toFixed(1)} ms`;
+    const freqText = Number(freq.toFixed(1)).toString();
+    freqLabel.textContent = `${freqText}   ${(time * 1000).toFixed(1)} ms`;
   };
 
   viewer.addEventListener('mousemove', updateHoverDisplay, { passive: true });


### PR DESCRIPTION
## Summary
- clean up frequency label formatting in axisRenderer.js
- update frequency hover text to omit `kHz` and drop trailing zeroes
- keep tooltip labels unchanged

## Testing
- `node --check modules/axisRenderer.js`
- `node --check modules/frequencyHover.js`


------
https://chatgpt.com/codex/tasks/task_e_687c48d5b9d8832ab757df38513691c7