### PR TITLE
Add counter badge to back button

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,13 +58,19 @@ let selectionExpandMode = false;
 let expandHistory = [];
 let currentExpandBlob = null;
 const expandBackBtn = document.getElementById('expandBackBtn');
+const expandBackCount = document.getElementById('expandBackCount');
 let ignoreNextPause = false;
 const canvasElem = document.getElementById("spectrogram-canvas");
 const offscreen = canvasElem.transferControlToOffscreen();
 const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
 specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
 function updateExpandBackBtn() {
-expandBackBtn.style.display = expandHistory.length > 0 ? 'inline-flex' : 'none';
+  const count = expandHistory.length;
+  expandBackBtn.style.display = count > 0 ? 'inline-flex' : 'none';
+  if (expandBackCount) {
+    expandBackCount.textContent = String(count);
+    expandBackCount.style.display = count > 0 ? 'flex' : 'none';
+  }
 }
 let stopBtnRafId = null;
 function showStopButton() {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -75,6 +75,7 @@
         <button id="setting" title="Spectrogram setting (Ctrl+S)" class="sidebar-button"><i class="fa-solid fa-sliders"></i></button>
         <button id="expandBackBtn" title="Back to previous session (Backspace)" class="sidebar-button">
           <i class="fa-solid fa-reply"></i>
+          <span id="expandBackCount" class="expand-back-count"></span>
         </button>
       </div>
       <!-- Tool Bar -->    

--- a/style.css
+++ b/style.css
@@ -1358,6 +1358,24 @@ input.tag-button.editing {
   background-color: #B91F1C;
 }
 
+#expandBackCount,
+#expandBackBtn .expand-back-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background-color: #f44336;
+  color: white;
+  border-radius: 50%;
+  padding: 0 4px;
+  font-size: 10px;
+  line-height: 14px;
+  min-width: 14px;
+  height: 14px;
+  display: none;
+  justify-content: center;
+  align-items: center;
+}
+
 #overlapInput {
   width: 45px;
   padding-right: 0;


### PR DESCRIPTION
## Summary
- show count of expand history on the back button

## Testing
- `node --check main.js`
- `node --check modules/frequencyHover.js`


------
https://chatgpt.com/codex/tasks/task_e_687c548fdb84832a837028c40e8c8390