### PR TITLE
Add zoom limit for HK imagery base layer

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -234,6 +234,13 @@ export function initMapPopup({
     const hkVectorGroup = L.layerGroup([hkVectorBase, hkVectorLabel]);
     const hkImageryGroup = L.layerGroup([hkImageryLayer, hkImageryLabel]);
 
+    map.on('zoomend', () => {
+      const currentZoom = map.getZoom();
+      if (currentZoom > 19 && map.hasLayer(hkImageryGroup)) {
+        map.setZoom(19);
+      }
+    });
+
     const baseLayers = {
       'OpenStreetMap': streets,
       'Esri Satellite': esriSatellite,


### PR DESCRIPTION
## Summary
- keep map zoom under 19 when HK imagery is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c819e2e30832a8b9d7e3e1ac6912e