### PR TITLE
Add Auto ID panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ import { initSidebar } from './modules/sidebar.js';
 import { initTagControl } from './modules/tagControl.js';
 import { initDropdown } from './modules/dropdown.js';
 import { showMessageBox } from './modules/messageBox.js';
+import { initAutoIdPanel } from './modules/autoIdPanel.js';
 import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
 const spectrogramHeight = 800;
@@ -890,6 +891,11 @@ document.body.classList.toggle('settings-open', isOpen);
 initExportCsv();
 initTrashProgram();
 initMapPopup();
+initAutoIdPanel({
+  spectrogramHeight,
+  getDuration,
+  getFreqRange: () => ({ min: currentFreqMin, max: currentFreqMax })
+});
 document.addEventListener('hide-spectrogram-hover', () => {
   freqHoverControl?.hideHover();
 });

--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -1,0 +1,82 @@
+import { initDropdown } from './dropdown.js';
+
+export function initAutoIdPanel({
+  buttonId = 'autoIdBtn',
+  panelId = 'auto-id-panel',
+  viewerId = 'viewer-container',
+  containerId = 'spectrogram-only',
+  spectrogramHeight = 800,
+  getDuration = () => 0,
+  getFreqRange = () => ({ min: 0, max: 0 })
+} = {}) {
+  const btn = document.getElementById(buttonId);
+  const panel = document.getElementById(panelId);
+  const viewer = document.getElementById(viewerId);
+  const container = document.getElementById(containerId);
+
+  if (!btn || !panel || !viewer) return;
+
+  btn.addEventListener('click', () => {
+    const isOpen = panel.classList.toggle('open');
+    document.body.classList.toggle('autoid-open', isOpen);
+  });
+
+  const callTypeDropdown = initDropdown('callTypeInput', ['CF-FM','FM-CF-FM','FM','FM-QCF','QCF']);
+  callTypeDropdown.select(0);
+  const harmonicDropdown = initDropdown('harmonicInput', ['0','1','2','3']);
+  harmonicDropdown.select(0);
+
+  const inputs = {
+    start: document.getElementById('startFreqInput'),
+    end: document.getElementById('endFreqInput'),
+    high: document.getElementById('highFreqInput'),
+    low: document.getElementById('lowFreqInput'),
+    knee: document.getElementById('kneeFreqInput'),
+    heel: document.getElementById('heelFreqInput'),
+  };
+  const bandwidthEl = document.getElementById('bandwidthVal');
+  const durationEl = document.getElementById('durationVal');
+
+  let active = null;
+  let startTime = null;
+  let endTime = null;
+
+  Object.values(inputs).forEach(el => {
+    if (!el) return;
+    el.readOnly = true;
+    el.addEventListener('click', () => {
+      if (active) active.classList.remove('active-get');
+      active = el;
+      el.classList.add('active-get');
+    });
+  });
+
+  function updateDerived() {
+    const high = parseFloat(inputs.high.value);
+    const low = parseFloat(inputs.low.value);
+    if (!isNaN(high) && !isNaN(low)) {
+      bandwidthEl.textContent = (high - low).toFixed(1);
+    }
+    if (startTime != null && endTime != null) {
+      durationEl.textContent = ((endTime - startTime) * 1000).toFixed(1);
+    }
+  }
+
+  viewer.addEventListener('click', (e) => {
+    if (!active) return;
+    const rect = viewer.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const scrollLeft = viewer.scrollLeft || 0;
+    const { min, max } = getFreqRange();
+    const freq = (1 - y / spectrogramHeight) * (max - min) + min;
+    const time = ((x + scrollLeft) / container.scrollWidth) * getDuration();
+    active.value = freq.toFixed(1);
+    active.dataset.time = time;
+    if (active === inputs.start) startTime = time;
+    if (active === inputs.end) endTime = time;
+    active.classList.remove('active-get');
+    active = null;
+    updateDerived();
+  });
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -68,6 +68,7 @@
         <button id="prevBtn" title="Previous file (↑)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (↓)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
         <button id="toggleTagModeBtn" title="Tag mode" class="sidebar-button"><i class="fa-solid fa-tags"></i></button>
+        <button id="autoIdBtn" title="Auto ID panel" class="sidebar-button"><i class="fa-solid fa-circle-info"></i></button>
         <button id="playPauseBtn" title="Play/Pause (Ctrl+P)" class="sidebar-button"><i class="fa-solid fa-play"></i></button>
         <button id="stopBtn" title="Stop" class="sidebar-button"><i class="fa-solid fa-stop"></i></button>
         <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
@@ -113,6 +114,39 @@
             <input type="checkbox" id="toggleGridSwitch">
             <span class="slider round"></span>
           </label>
+        </label>
+      </div>
+      <div id="auto-id-panel">
+        <div class="panel-title">Auto ID Panel</div>
+        <label>Call type:
+          <button id="callTypeInput" class="dropdown-button">CF-FM</button>
+        </label>
+        <label>Harmonic no.:
+          <button id="harmonicInput" class="dropdown-button">0</button>
+        </label>
+        <label>Start freq.:
+          <input id="startFreqInput" class="autoid-input" type="text" readonly>
+        </label>
+        <label>End freq.:
+          <input id="endFreqInput" class="autoid-input" type="text" readonly>
+        </label>
+        <label>High.freq.:
+          <input id="highFreqInput" class="autoid-input" type="text" readonly>
+        </label>
+        <label>Low.freq.:
+          <input id="lowFreqInput" class="autoid-input" type="text" readonly>
+        </label>
+        <label>Knee freq.:
+          <input id="kneeFreqInput" class="autoid-input" type="text" readonly>
+        </label>
+        <label>Heel freq.:
+          <input id="heelFreqInput" class="autoid-input" type="text" readonly>
+        </label>
+        <label>Bandwidth:
+          <span id="bandwidthVal">-</span>
+        </label>
+        <label>Duration:
+          <span id="durationVal">-</span>
         </label>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -573,6 +573,53 @@ input[type="file"]:hover {
   height: 0;
 }
 
+#auto-id-panel {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 30px);
+  transform: translateX(-50%) scale(0.9);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px;
+  width: 260px;
+  background-color: #fff;
+  border-radius: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid #eee;
+  font-family: 'Noto Sans HK', sans-serif;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+#auto-id-panel.open {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 100;
+}
+
+#auto-id-panel .panel-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+#auto-id-panel label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+#auto-id-panel .autoid-input {
+  width: 80px;
+  padding: 2px 4px;
+}
+
+#auto-id-panel .active-get {
+  background-color: #ddd;
+}
+
 /* === Sidebar Button === */
 .sidebar-button {
   width: 30px;
@@ -801,6 +848,10 @@ body.settings-open #setting {
 }
 
 body.map-open #mapBtn {
+  background-color: #007bff;
+}
+
+body.autoid-open #autoIdBtn {
   background-color: #007bff;
 }
 


### PR DESCRIPTION
## Summary
- add Auto ID panel module for capturing frequency/time from spectrogram
- integrate Auto ID panel in main page
- style Auto ID panel and add toggle button in top bar

## Testing
- `node --check modules/autoIdPanel.js`
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_687c9dd04434832a9f828d23f46fb738