### PR TITLE
Add reset for Auto ID panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ import { initSidebar } from './modules/sidebar.js';
 import { initTagControl } from './modules/tagControl.js';
 import { initDropdown } from './modules/dropdown.js';
 import { showMessageBox } from './modules/messageBox.js';
+import { initAutoIdPanel } from './modules/autoIdPanel.js';
 import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
 const spectrogramHeight = 800;
@@ -53,6 +54,7 @@ let currentFftSize = 1024;
 let currentOverlap = 'auto';
 let overlapWarningShown = false;
 let freqHoverControl = null;
+let autoIdControl = null;
 const sampleRateBtn = document.getElementById('sampleRateInput');
 let selectionExpandMode = false;
 let expandHistory = [];
@@ -232,9 +234,10 @@ function hideDropOverlay() {
 overlay.style.display = 'none';
 overlay.style.pointerEvents = 'none';
 hoverLineElem.style.display = 'block';
-hoverLineVElem.style.display = 'block';
-freqHoverControl?.setPersistentLinesEnabled(true);
-freqHoverControl?.refreshHover();
+  hoverLineVElem.style.display = 'block';
+  freqHoverControl?.setPersistentLinesEnabled(true);
+  freqHoverControl?.refreshHover();
+  autoIdControl?.updateMarkers();
 }
 
 showDropOverlay();
@@ -272,6 +275,7 @@ updateExpandBackBtn();
       loadingOverlay.style.display = 'none';
     }
     freqHoverControl?.refreshHover();
+    autoIdControl?.updateMarkers();
     drawColorBar(getCurrentColorMap());
     updateSpectrogramSettingsText();
   },
@@ -363,10 +367,11 @@ currentFreqMax,
 getOverlapPercent(),
 () => {
 duration = getWavesurfer().getDuration();
-zoomControl.applyZoom();
-renderAxes();
-freqHoverControl?.refreshHover();
-}
+    zoomControl.applyZoom();
+    renderAxes();
+    freqHoverControl?.refreshHover();
+    autoIdControl?.updateMarkers();
+  }
 );
 updateSpectrogramSettingsText();
 }
@@ -429,6 +434,7 @@ getZoomLevel: () => zoomControl.getZoomLevel(),
   });
   } else {
     freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
+    autoIdControl?.updateMarkers();
   }
   updateProgressLine(getWavesurfer().getCurrentTime());
 };
@@ -441,7 +447,7 @@ getDuration,
 renderAxes,
 wrapper,
 () => { freqHoverControl?.hideHover(); },
-() => { freqHoverControl?.refreshHover(); },
+() => { freqHoverControl?.refreshHover(); autoIdControl?.updateMarkers(); },
 () => selectionExpandMode
 );
 
@@ -456,6 +462,7 @@ viewer.addEventListener('scroll', () => {
   const ws = getWavesurfer();
   if (!ws) return;
   updateProgressLine(ws.getCurrentTime());
+  autoIdControl?.updateMarkers();
 });
 
 progressLineElem.addEventListener('mousedown', (e) => {
@@ -542,9 +549,10 @@ currentFreqMax,
 getOverlapPercent(),
 () => {
 duration = getWavesurfer().getDuration();
-zoomControl.applyZoom();
-renderAxes();
+    zoomControl.applyZoom();
+    renderAxes();
   freqHoverControl?.refreshHover();
+  autoIdControl?.updateMarkers();
   }
   );
   drawColorBar(colorMap);
@@ -574,6 +582,7 @@ freqHoverControl?.clearSelections();
       loadingOverlay.style.display = 'none';
     }
     freqHoverControl?.refreshHover();
+    autoIdControl?.updateMarkers();
     drawColorBar(getCurrentColorMap());
     updateSpectrogramSettingsText();
   },
@@ -596,6 +605,7 @@ getPlugin()?.render();
 requestAnimationFrame(() => {
 renderAxes();
 freqHoverControl?.refreshHover();
+autoIdControl?.updateMarkers();
 });
 });
 
@@ -606,6 +616,7 @@ progressLineElem.style.display = 'none';
 updateProgressLine(0);
 renderAxes();
 freqHoverControl?.refreshHover();
+autoIdControl?.updateMarkers();
 });
 
 document.body.addEventListener('touchstart', () => {
@@ -737,8 +748,9 @@ getOverlapPercent(),
 () => {
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
-renderAxes();
-freqHoverControl?.refreshHover();
+  renderAxes();
+  freqHoverControl?.refreshHover();
+  autoIdControl?.updateMarkers();
 },
 currentFftSize
 );
@@ -757,6 +769,7 @@ getOverlapPercent()
 );
 
 freqHoverControl?.refreshHover();
+autoIdControl?.updateMarkers();
 
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
@@ -779,6 +792,7 @@ getOverlapPercent()
 );
 
 freqHoverControl?.refreshHover();
+autoIdControl?.updateMarkers();
 
 duration = getWavesurfer().getDuration();
 zoomControl.applyZoom();
@@ -786,6 +800,7 @@ renderAxes();
 
 if (freqHoverControl) {
 freqHoverControl.setFrequencyRange(currentFreqMin, currentFreqMax);
+autoIdControl?.updateMarkers();
 }
 updateSpectrogramSettingsText();
 }
@@ -890,6 +905,11 @@ document.body.classList.toggle('settings-open', isOpen);
 initExportCsv();
 initTrashProgram();
 initMapPopup();
+autoIdControl = initAutoIdPanel({
+  spectrogramHeight,
+  getDuration,
+  getFreqRange: () => ({ min: currentFreqMin, max: currentFreqMax })
+});
 document.addEventListener('hide-spectrogram-hover', () => {
   freqHoverControl?.hideHover();
 });
@@ -956,6 +976,7 @@ expandBackBtn.addEventListener('click', async () => {
   updateFrequencyRange(prevMin, prevMax);
 
   updateExpandBackBtn();
+  autoIdControl?.reset();
 });
 
 document.addEventListener('keydown', (e) => {
@@ -1007,5 +1028,6 @@ window.addEventListener('resize', () => {
   if (container.clientWidth !== prevWidth) {
     renderAxes();
     freqHoverControl?.refreshHover();
+    autoIdControl?.updateMarkers();
   }
 });

--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -1,0 +1,155 @@
+import { initDropdown } from './dropdown.js';
+
+export function initAutoIdPanel({
+  buttonId = 'autoIdBtn',
+  panelId = 'auto-id-panel',
+  viewerId = 'viewer-container',
+  containerId = 'spectrogram-only',
+  overlayId = 'fixed-overlay',
+  spectrogramHeight = 800,
+  getDuration = () => 0,
+  getFreqRange = () => ({ min: 0, max: 0 })
+} = {}) {
+  const btn = document.getElementById(buttonId);
+  const panel = document.getElementById(panelId);
+  const viewer = document.getElementById(viewerId);
+  const container = document.getElementById(containerId);
+  const overlay = document.getElementById(overlayId);
+
+  if (!btn || !panel || !viewer) return;
+
+  btn.addEventListener('click', () => {
+    const isOpen = panel.classList.toggle('open');
+    document.body.classList.toggle('autoid-open', isOpen);
+  });
+
+  const callTypeDropdown = initDropdown('callTypeInput', ['CF-FM','FM-CF-FM','FM','FM-QCF','QCF']);
+  callTypeDropdown.select(0);
+  const harmonicDropdown = initDropdown('harmonicInput', ['0','1','2','3']);
+  harmonicDropdown.select(0);
+
+  const inputs = {
+    start: document.getElementById('startFreqInput'),
+    end: document.getElementById('endFreqInput'),
+    high: document.getElementById('highFreqInput'),
+    low: document.getElementById('lowFreqInput'),
+    knee: document.getElementById('kneeFreqInput'),
+    heel: document.getElementById('heelFreqInput'),
+  };
+  const bandwidthEl = document.getElementById('bandwidthVal');
+  const durationEl = document.getElementById('durationVal');
+
+  const markerColors = {
+    start: '#e74c3c',
+    end: '#27ae60',
+    high: '#3498db',
+    low: '#9b59b6',
+    knee: '#f39c12',
+    heel: '#16a085'
+  };
+
+  const markers = {
+    start: { el: null, freq: null, time: null },
+    end: { el: null, freq: null, time: null },
+    high: { el: null, freq: null, time: null },
+    low: { el: null, freq: null, time: null },
+    knee: { el: null, freq: null, time: null },
+    heel: { el: null, freq: null, time: null }
+  };
+
+  let active = null;
+  let startTime = null;
+  let endTime = null;
+
+  Object.entries(inputs).forEach(([key, el]) => {
+    if (!el) return;
+    el.dataset.key = key;
+    el.readOnly = true;
+    el.addEventListener('click', () => {
+      if (active) active.classList.remove('active-get');
+      active = el;
+      el.classList.add('active-get');
+    });
+  });
+
+  function updateDerived() {
+    const high = parseFloat(inputs.high.value);
+    const low = parseFloat(inputs.low.value);
+    if (!isNaN(high) && !isNaN(low)) {
+      bandwidthEl.textContent = (high - low).toFixed(1);
+    }
+    if (startTime != null && endTime != null) {
+      durationEl.textContent = ((endTime - startTime) * 1000).toFixed(1);
+    }
+  }
+
+  function createMarkerEl(key) {
+    const el = document.createElement('i');
+    el.className = `fa-solid fa-xmark freq-marker marker-${key}`;
+    el.style.color = markerColors[key];
+    overlay.appendChild(el);
+    return el;
+  }
+
+  function updateMarkers() {
+    const { min, max } = getFreqRange();
+    const actualWidth = container.scrollWidth;
+    Object.entries(markers).forEach(([key, m]) => {
+      if (!m.el) m.el = createMarkerEl(key);
+      if (m.freq == null || m.time == null) {
+        m.el.style.display = 'none';
+        return;
+      }
+      const x = (m.time / getDuration()) * actualWidth - viewer.scrollLeft;
+      const y = (1 - (m.freq - min) / (max - min)) * spectrogramHeight;
+      m.el.style.left = `${x}px`;
+      m.el.style.top = `${y}px`;
+      m.el.style.display = 'block';
+    });
+  }
+
+  function reset() {
+    Object.values(inputs).forEach(el => {
+      if (!el) return;
+      el.value = '';
+      delete el.dataset.time;
+      el.classList.remove('active-get');
+    });
+    bandwidthEl.textContent = '-';
+    durationEl.textContent = '-';
+    startTime = null;
+    endTime = null;
+    Object.values(markers).forEach(m => {
+      m.freq = null;
+      m.time = null;
+      if (m.el) m.el.style.display = 'none';
+    });
+    active = null;
+  }
+
+  viewer.addEventListener('click', (e) => {
+    if (!active) return;
+    const rect = viewer.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const scrollLeft = viewer.scrollLeft || 0;
+    const { min, max } = getFreqRange();
+    const freq = (1 - y / spectrogramHeight) * (max - min) + min;
+    const time = ((x + scrollLeft) / container.scrollWidth) * getDuration();
+    const key = active.dataset.key;
+    active.value = freq.toFixed(1);
+    active.dataset.time = time;
+    markers[key].freq = freq;
+    markers[key].time = time;
+    if (active === inputs.start) startTime = time;
+    if (active === inputs.end) endTime = time;
+    active.classList.remove('active-get');
+    active = null;
+    updateDerived();
+    updateMarkers();
+  });
+
+  viewer.addEventListener('scroll', updateMarkers);
+
+  return { updateMarkers, reset };
+}

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -68,6 +68,7 @@
         <button id="prevBtn" title="Previous file (↑)" class="sidebar-button"><i class="fas fa-arrow-up"></i></button>
         <button id="nextBtn" title="Next file (↓)" class="sidebar-button"><i class="fas fa-arrow-down"></i></button>
         <button id="toggleTagModeBtn" title="Tag mode" class="sidebar-button"><i class="fa-solid fa-tags"></i></button>
+        <button id="autoIdBtn" title="Auto ID panel" class="sidebar-button"><i class="fa-solid fa-circle-info"></i></button>
         <button id="playPauseBtn" title="Play/Pause (Ctrl+P)" class="sidebar-button"><i class="fa-solid fa-play"></i></button>
         <button id="stopBtn" title="Stop" class="sidebar-button"><i class="fa-solid fa-stop"></i></button>
         <button id="exportBtn" title="Export" class="sidebar-button"><i class="fa-solid fa-file-export"></i></button>
@@ -114,6 +115,75 @@
             <span class="slider round"></span>
           </label>
         </label>
+      </div>
+      <div id="auto-id-panel">
+        <div class="panel-title">Auto ID Panel</div>
+        <div class="autoid-row">
+          <span class="autoid-label">Call type:</span>
+          <div class="autoid-field">
+            <button id="callTypeInput" class="dropdown-button">CF-FM</button>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Harmonic no.:</span>
+          <div class="autoid-field">
+            <button id="harmonicInput" class="dropdown-button">0</button>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Start freq.:</span>
+          <div class="autoid-field">
+            <input id="startFreqInput" class="autoid-input" type="text" readonly>
+            <i class="fa-solid fa-xmark autoid-marker marker-start"></i>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">End freq.:</span>
+          <div class="autoid-field">
+            <input id="endFreqInput" class="autoid-input" type="text" readonly>
+            <i class="fa-solid fa-xmark autoid-marker marker-end"></i>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">High.freq.:</span>
+          <div class="autoid-field">
+            <input id="highFreqInput" class="autoid-input" type="text" readonly>
+            <i class="fa-solid fa-xmark autoid-marker marker-high"></i>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Low.freq.:</span>
+          <div class="autoid-field">
+            <input id="lowFreqInput" class="autoid-input" type="text" readonly>
+            <i class="fa-solid fa-xmark autoid-marker marker-low"></i>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Knee freq.:</span>
+          <div class="autoid-field">
+            <input id="kneeFreqInput" class="autoid-input" type="text" readonly>
+            <i class="fa-solid fa-xmark autoid-marker marker-knee"></i>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Heel freq.:</span>
+          <div class="autoid-field">
+            <input id="heelFreqInput" class="autoid-input" type="text" readonly>
+            <i class="fa-solid fa-xmark autoid-marker marker-heel"></i>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Bandwidth:</span>
+          <div class="autoid-field">
+            <span id="bandwidthVal">-</span>
+          </div>
+        </div>
+        <div class="autoid-row">
+          <span class="autoid-label">Duration:</span>
+          <div class="autoid-field">
+            <span id="durationVal">-</span>
+          </div>
+        </div>
       </div>
     </div>
 <!-------- Spectrogram Start -------->

--- a/style.css
+++ b/style.css
@@ -573,6 +573,81 @@ input[type="file"]:hover {
   height: 0;
 }
 
+#auto-id-panel {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 30px);
+  transform: translateX(-50%) scale(0.9);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 12px;
+  width: 260px;
+  background-color: #fff;
+  border-radius: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: 1px solid #eee;
+  font-family: 'Noto Sans HK', sans-serif;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+#auto-id-panel.open {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 100;
+}
+
+#auto-id-panel .panel-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+#auto-id-panel .autoid-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+#auto-id-panel .autoid-label {
+  width: 90px;
+}
+
+#auto-id-panel .autoid-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+#auto-id-panel .autoid-input {
+  width: 40px;
+  padding: 2px 4px;
+}
+
+#auto-id-panel .active-get {
+  background-color: #ddd;
+}
+
+.autoid-marker {
+  margin-left: 4px;
+}
+
+.freq-marker {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 30;
+}
+
+.marker-start { color: #e74c3c; }
+.marker-end { color: #27ae60; }
+.marker-high { color: #3498db; }
+.marker-low { color: #9b59b6; }
+.marker-knee { color: #f39c12; }
+.marker-heel { color: #16a085; }
+
 /* === Sidebar Button === */
 .sidebar-button {
   width: 30px;
@@ -801,6 +876,10 @@ body.settings-open #setting {
 }
 
 body.map-open #mapBtn {
+  background-color: #007bff;
+}
+
+body.autoid-open #autoIdBtn {
   background-color: #007bff;
 }
 


### PR DESCRIPTION
## Summary
- refactor Auto ID panel layout so labels and inputs align
- shrink Auto ID input boxes and styling
- hide markers and clear values when leaving expand mode
- reset Auto ID state on Back button

## Testing
- `node --check modules/autoIdPanel.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_687c9dd04434832a9f828d23f46fb738