### PR TITLE
Add tooltip and drag to auto-id markers

### DIFF
--- a/main.js
+++ b/main.js
@@ -908,7 +908,9 @@ initMapPopup();
 autoIdControl = initAutoIdPanel({
   spectrogramHeight,
   getDuration,
-  getFreqRange: () => ({ min: currentFreqMin, max: currentFreqMax })
+  getFreqRange: () => ({ min: currentFreqMin, max: currentFreqMax }),
+  hideHover: () => freqHoverControl?.hideHover(),
+  refreshHover: () => freqHoverControl?.refreshHover()
 });
 document.addEventListener('hide-spectrogram-hover', () => {
   freqHoverControl?.hideHover();

--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -8,7 +8,9 @@ export function initAutoIdPanel({
   overlayId = 'fixed-overlay',
   spectrogramHeight = 800,
   getDuration = () => 0,
-  getFreqRange = () => ({ min: 0, max: 0 })
+  getFreqRange = () => ({ min: 0, max: 0 }),
+  hideHover = () => {},
+  refreshHover = () => {}
 } = {}) {
   const btn = document.getElementById(buttonId);
   const panel = document.getElementById(panelId);
@@ -60,6 +62,7 @@ export function initAutoIdPanel({
   let active = null;
   let startTime = null;
   let endTime = null;
+  let draggingKey = null;
 
   Object.entries(inputs).forEach(([key, el]) => {
     if (!el) return;
@@ -87,6 +90,18 @@ export function initAutoIdPanel({
     const el = document.createElement('i');
     el.className = `fa-solid fa-xmark freq-marker marker-${key}`;
     el.style.color = markerColors[key];
+    el.dataset.key = key;
+    el.title = `${key.charAt(0).toUpperCase() + key.slice(1)} freq. marker`;
+    el.addEventListener('mouseenter', hideHover);
+    el.addEventListener('mouseleave', refreshHover);
+    el.addEventListener('mousedown', (ev) => {
+      ev.stopPropagation();
+      hideHover();
+      draggingKey = key;
+      document.addEventListener('mousemove', onMarkerDrag, { passive: true });
+      document.addEventListener('mouseup', stopMarkerDrag, { once: true });
+    });
+    el.addEventListener('click', (ev) => ev.stopPropagation());
     overlay.appendChild(el);
     return el;
   }
@@ -106,6 +121,34 @@ export function initAutoIdPanel({
       m.el.style.top = `${y}px`;
       m.el.style.display = 'block';
     });
+  }
+
+  function onMarkerDrag(e) {
+    if (!draggingKey) return;
+    const rect = viewer.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const scrollLeft = viewer.scrollLeft || 0;
+    const { min, max } = getFreqRange();
+    const freq = (1 - y / spectrogramHeight) * (max - min) + min;
+    const time = ((x + scrollLeft) / container.scrollWidth) * getDuration();
+    const input = inputs[draggingKey];
+    if (input) {
+      input.value = freq.toFixed(1);
+      input.dataset.time = time;
+      if (input === inputs.start) startTime = time;
+      if (input === inputs.end) endTime = time;
+    }
+    markers[draggingKey].freq = freq;
+    markers[draggingKey].time = time;
+    updateDerived();
+    updateMarkers();
+  }
+
+  function stopMarkerDrag() {
+    draggingKey = null;
+    document.removeEventListener('mousemove', onMarkerDrag);
+    refreshHover();
   }
 
   function reset() {

--- a/style.css
+++ b/style.css
@@ -137,6 +137,10 @@ html, body {
 #fixed-overlay > * {
   pointer-events: none;
 }
+#fixed-overlay > .freq-marker {
+  pointer-events: auto;
+  cursor: move !important;
+}
 #progress-line {
   pointer-events: auto;
 }
@@ -641,7 +645,8 @@ input[type="file"]:hover {
 .freq-marker {
   position: absolute;
   transform: translate(-50%, -50%);
-  pointer-events: none;
+  pointer-events: auto;
+  cursor: move !important;
   z-index: 30;
 }
 


### PR DESCRIPTION
## Summary
- allow markers on the spectrogram overlay to be interactive
- show tooltip text when hovering over markers
- make markers draggable so auto‑id panel values update
- apply move cursor style on markers
- fix CSS so markers respond to pointer events
- hide spectrogram hoverlines when the cursor is over a marker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687cabb29808832a9b4878b77a618321