### PR TITLE
Reset Auto ID markers on new audio or expand

### DIFF
--- a/main.js
+++ b/main.js
@@ -504,6 +504,7 @@ viewer.addEventListener('expand-selection', async (e) => {
       freqHoverControl?.hideHover();
       freqHoverControl?.clearSelections();
       updateExpandBackBtn();
+      autoIdControl?.reset();
     }
   }
 });
@@ -527,6 +528,7 @@ viewer.addEventListener('fit-window-selection', async (e) => {
       freqHoverControl?.hideHover();
       freqHoverControl?.clearSelections();
       updateExpandBackBtn();
+      autoIdControl?.reset();
     }
   }
 });
@@ -1006,6 +1008,7 @@ document.addEventListener("file-loaded", async () => {
   expandHistory = [];
   currentExpandBlob = null;
   updateExpandBackBtn();
+  autoIdControl?.reset();
   if (currentFile) {
     const arrayBuf = await currentFile.arrayBuffer();
     const ac = new (window.AudioContext || window.webkitAudioContext)();


### PR DESCRIPTION
## Summary
- clear Auto ID panel markers whenever a new WAV is loaded
- reset Auto ID panel when expanding to a new cropped selection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cb35be310832a857f2837e8145318