### PR TITLE
Add tabbed Auto ID panel

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -17,6 +17,24 @@ export function initAutoIdPanel({
   const viewer = document.getElementById(viewerId);
   const container = document.getElementById(containerId);
   const overlay = document.getElementById(overlayId);
+  const tabsContainer = document.getElementById("autoid-tabs");
+  const tabs = [];
+  const tabData = Array.from({ length: 10 }, () => ({
+    callType: 0,
+    harmonic: 0,
+    inputs: { start: "", end: "", high: "", low: "", knee: "", heel: "" },
+    startTime: null,
+    endTime: null,
+    markers: {
+      start: { freq: null, time: null },
+      end: { freq: null, time: null },
+      high: { freq: null, time: null },
+      low: { freq: null, time: null },
+      knee: { freq: null, time: null },
+      heel: { freq: null, time: null }
+    }
+  }));
+  let currentTab = 0;
 
   if (!btn || !panel || !viewer) return;
 
@@ -29,6 +47,17 @@ export function initAutoIdPanel({
   callTypeDropdown.select(0);
   const harmonicDropdown = initDropdown('harmonicInput', ['0','1','2','3']);
   harmonicDropdown.select(0);
+  if (tabsContainer) {
+    for (let i = 0; i < 10; i++) {
+      const t = document.createElement("button");
+      t.textContent = `Signal ${i + 1}`;
+      t.className = "tab-btn";
+      if (i === 0) t.classList.add("active");
+      t.addEventListener("click", () => switchTab(i));
+      tabsContainer.appendChild(t);
+      tabs.push(t);
+    }
+  }
 
   const inputs = {
     start: document.getElementById('startFreqInput'),
@@ -64,6 +93,47 @@ export function initAutoIdPanel({
   let endTime = null;
   let draggingKey = null;
   let markersEnabled = true;
+  function saveCurrentTab() {
+    const data = tabData[currentTab];
+    data.callType = callTypeDropdown.selectedIndex;
+    data.harmonic = harmonicDropdown.selectedIndex;
+    data.startTime = startTime;
+    data.endTime = endTime;
+    Object.keys(inputs).forEach(k => {
+      data.inputs[k] = inputs[k].value;
+      data.markers[k].freq = markers[k].freq;
+      data.markers[k].time = markers[k].time;
+    });
+  }
+
+  function loadTab(idx) {
+    const data = tabData[idx];
+    callTypeDropdown.select(data.callType);
+    harmonicDropdown.select(data.harmonic);
+    Object.keys(inputs).forEach(k => {
+      inputs[k].value = data.inputs[k] || "" ;
+      if (data.markers[k].time != null) {
+        inputs[k].dataset.time = data.markers[k].time;
+      } else {
+        delete inputs[k].dataset.time;
+      }
+      markers[k].freq = data.markers[k].freq;
+      markers[k].time = data.markers[k].time;
+    });
+    startTime = data.startTime;
+    endTime = data.endTime;
+    updateDerived();
+    updateMarkers();
+  }
+
+  function switchTab(idx) {
+    if (idx === currentTab) return;
+    saveCurrentTab();
+    if (tabs[currentTab]) tabs[currentTab].classList.remove("active");
+    currentTab = idx;
+    if (tabs[currentTab]) tabs[currentTab].classList.add("active");
+    loadTab(idx);
+  }
 
   function setMarkerInteractivity(enabled) {
     markersEnabled = enabled;
@@ -71,6 +141,7 @@ export function initAutoIdPanel({
   }
 
   setMarkerInteractivity(true);
+  loadTab(0);
 
   Object.entries(inputs).forEach(([key, el]) => {
     if (!el) return;
@@ -149,8 +220,12 @@ export function initAutoIdPanel({
       if (input === inputs.start) startTime = time;
       if (input === inputs.end) endTime = time;
     }
+    tabData[currentTab].startTime = startTime;
+    tabData[currentTab].endTime = endTime;
     markers[draggingKey].freq = freq;
     markers[draggingKey].time = time;
+    tabData[currentTab].markers[draggingKey].freq = freq;
+    tabData[currentTab].markers[draggingKey].time = time;
     updateDerived();
     updateMarkers();
   }
@@ -162,9 +237,19 @@ export function initAutoIdPanel({
   }
 
   function reset() {
+    tabData.forEach(d => {
+      d.callType = 0;
+      d.harmonic = 0;
+      Object.keys(d.inputs).forEach(k => { d.inputs[k] = ""; });
+      d.startTime = null;
+      d.endTime = null;
+      Object.keys(d.markers).forEach(k => { d.markers[k].freq = null; d.markers[k].time = null; });
+    });
+    callTypeDropdown.select(0);
+    harmonicDropdown.select(0);
     Object.values(inputs).forEach(el => {
       if (!el) return;
-      el.value = '';
+      el.value = "";
       delete el.dataset.time;
       el.classList.remove('active-get');
     });
@@ -179,8 +264,8 @@ export function initAutoIdPanel({
     });
     active = null;
     setMarkerInteractivity(true);
+    loadTab(currentTab);
   }
-
   viewer.addEventListener('click', (e) => {
     if (!active) return;
     const rect = viewer.getBoundingClientRect();
@@ -197,6 +282,10 @@ export function initAutoIdPanel({
     markers[key].time = time;
     if (active === inputs.start) startTime = time;
     if (active === inputs.end) endTime = time;
+    tabData[currentTab].startTime = startTime;
+    tabData[currentTab].endTime = endTime;
+    tabData[currentTab].markers[key].freq = freq;
+    tabData[currentTab].markers[key].time = time;
     active.classList.remove('active-get');
     active = null;
     setMarkerInteractivity(true);

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -118,6 +118,9 @@
       </div>
       <div id="auto-id-panel">
         <div class="panel-title">Auto ID Panel</div>
+        <div class="autoid-body">
+          <div id="autoid-tabs"></div>
+          <div id="autoid-fields">
         <div class="autoid-row">
           <span class="autoid-label">Call type:</span>
           <div class="autoid-field">
@@ -192,6 +195,8 @@
             <span class="autoid-unit">ms</span>
           </div>
         </div>
+        </div>
+      </div>
       </div>
     </div>
 <!-------- Spectrogram Start -------->

--- a/style.css
+++ b/style.css
@@ -586,7 +586,7 @@ input[type="file"]:hover {
   flex-direction: column;
   gap: 6px;
   padding: 8px 12px;
-  width: 260px;
+  width: 300px;
   background-color: #fff;
   border-radius: 20px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
@@ -636,6 +636,31 @@ input[type="file"]:hover {
 
 #auto-id-panel .active-get {
   background-color: #ddd;
+}
+#auto-id-panel .autoid-body {
+  display: flex;
+}
+#autoid-tabs {
+  display: flex;
+  flex-direction: column;
+  margin-right: 6px;
+}
+#autoid-tabs button {
+  margin-bottom: 4px;
+  padding: 2px 4px;
+  width: 70px;
+  cursor: pointer;
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+#autoid-tabs button.active {
+  background-color: #ccc;
+}
+#autoid-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .autoid-marker {


### PR DESCRIPTION
## Summary
- add left-sided vertical tabs to Auto ID panel
- style tabs and panel layout
- keep independent parameters for each tab in Auto ID logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687cb5b317c0832a8c34b7ce68b1929c