### PR TITLE
Update auto ID panel tabs

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -19,7 +19,8 @@ export function initAutoIdPanel({
   const overlay = document.getElementById(overlayId);
   const tabsContainer = document.getElementById("autoid-tabs");
   const tabs = [];
-  const tabData = Array.from({ length: 10 }, () => ({
+  const TAB_COUNT = 5;
+  const tabData = Array.from({ length: TAB_COUNT }, () => ({
     callType: 0,
     harmonic: 0,
     inputs: { start: "", end: "", high: "", low: "", knee: "", heel: "" },
@@ -48,9 +49,9 @@ export function initAutoIdPanel({
   const harmonicDropdown = initDropdown('harmonicInput', ['0','1','2','3']);
   harmonicDropdown.select(0);
   if (tabsContainer) {
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < TAB_COUNT; i++) {
       const t = document.createElement("button");
-      t.textContent = `Signal ${i + 1}`;
+      t.textContent = `${i + 1}`;
       t.className = "tab-btn";
       if (i === 0) t.classList.add("active");
       t.addEventListener("click", () => switchTab(i));

--- a/style.css
+++ b/style.css
@@ -639,21 +639,23 @@ input[type="file"]:hover {
 }
 #auto-id-panel .autoid-body {
   display: flex;
+  flex-direction: column;
 }
 #autoid-tabs {
   display: flex;
-  flex-direction: column;
-  margin-right: 15px;
+  flex-direction: row;
+  margin-bottom: 8px;
 }
 #autoid-tabs button {
-  margin-bottom: 4px;
+  margin-right: 4px;
   padding: 2px 4px;
   width: 70px;
   height: 25px;
   cursor: pointer;
   background-color: #eee;
   border: 1px solid #ccc;
-  border-radius: 6px;
+  border-radius: 6px 6px 0 0;
+  transition: background-color 0.25s ease;
 }
 #autoid-tabs button.active {
   background-color: #ccc;


### PR DESCRIPTION
## Summary
- simplify Auto ID panel tab names
- show tabs horizontally at the top
- keep existing colour scheme
- centralize tab count constant
- tweak tab button style

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687dcad6e6a4832a8cb908cb330ba282