### PR TITLE
Switch Auto ID panel to two-column grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -586,7 +586,7 @@ input[type="file"]:hover {
   flex-direction: column;
   gap: 6px;
   padding: 8px 12px;
-  width: 300px;
+  width: 340px;
   background-color: #fff;
   border-radius: 20px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
@@ -661,9 +661,10 @@ input[type="file"]:hover {
   background-color: #ccc;
 }
 #autoid-fields {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  column-gap: 12px;
+  row-gap: 6px;
 }
 
 .autoid-marker {


### PR DESCRIPTION
## Summary
- switch auto-id fields to a two-column grid layout
- widen the auto ID panel to fit the grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dd107b590832aa7fac7c46c22c3df