### PR TITLE
Add active tab reset for Auto ID panel

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -17,6 +17,7 @@ export function initAutoIdPanel({
   const viewer = document.getElementById(viewerId);
   const container = document.getElementById(containerId);
   const overlay = document.getElementById(overlayId);
+  const resetTabBtn = document.getElementById('autoIdTabResetBtn');
   const tabsContainer = document.getElementById("autoid-tabs");
   const tabs = [];
   const TAB_COUNT = 5;
@@ -43,6 +44,8 @@ export function initAutoIdPanel({
     const isOpen = panel.classList.toggle('open');
     document.body.classList.toggle('autoid-open', isOpen);
   });
+
+  resetTabBtn?.addEventListener('click', resetCurrentTab);
 
   const callTypeDropdown = initDropdown('callTypeInput', ['CF-FM','FM-CF-FM','FM','FM-QCF','QCF']);
   callTypeDropdown.select(0);
@@ -232,6 +235,38 @@ export function initAutoIdPanel({
     refreshHover();
   }
 
+  function resetTabData(tab) {
+    tab.callType = 0;
+    tab.harmonic = 0;
+    Object.keys(tab.inputs).forEach(k => { tab.inputs[k] = ""; });
+    tab.startTime = null;
+    tab.endTime = null;
+    Object.values(tab.markers).forEach(m => {
+      m.freq = null;
+      m.time = null;
+      if (m.el) m.el.style.display = 'none';
+    });
+  }
+
+  function resetCurrentTab() {
+    resetTabData(tabData[currentTab]);
+    callTypeDropdown.select(0);
+    harmonicDropdown.select(0);
+    Object.values(inputs).forEach(el => {
+      if (!el) return;
+      el.value = "";
+      delete el.dataset.time;
+      el.classList.remove('active-get');
+    });
+    bandwidthEl.textContent = '-';
+    durationEl.textContent = '-';
+    startTime = null;
+    endTime = null;
+    active = null;
+    setMarkerInteractivity(true);
+    loadTab(currentTab);
+  }
+
   function reset() {
     tabData.forEach(d => {
       d.callType = 0;
@@ -291,5 +326,5 @@ export function initAutoIdPanel({
 
   viewer.addEventListener('scroll', updateMarkers);
 
-  return { updateMarkers, reset };
+  return { updateMarkers, reset, resetCurrentTab };
 }

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -117,7 +117,12 @@
         </label>
       </div>
       <div id="auto-id-panel">
-        <div class="panel-title">Auto ID Panel</div>
+        <div class="panel-title">
+          <span>Auto ID Panel</span>
+          <button id="autoIdTabResetBtn" class="panel-reset-btn" title="Reset active tab">
+            <i class="fa-solid fa-rotate-left"></i>
+          </button>
+        </div>
         <div class="autoid-body">
           <div id="autoid-tabs"></div>
           <div id="autoid-fields">

--- a/style.css
+++ b/style.css
@@ -604,8 +604,21 @@ input[type="file"]:hover {
 }
 
 #auto-id-panel .panel-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-weight: bold;
   margin-bottom: 4px;
+}
+
+#auto-id-panel .panel-reset-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+#auto-id-panel .panel-reset-btn i {
+  color: #555;
 }
 
 #auto-id-panel .autoid-row {


### PR DESCRIPTION
## Summary
- add reset button next to Auto ID Panel title
- style reset button in panel header
- implement logic to clear values and markers only for active tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ddae63f98832a93c328e11ffb023c