### PR TITLE
Add reset buttons for Auto ID panel inputs

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -149,6 +149,35 @@ export function initAutoIdPanel({
     });
   });
 
+  function resetField(key) {
+    const input = inputs[key];
+    if (!input) return;
+    input.value = '';
+    delete input.dataset.time;
+    input.classList.remove('active-get');
+    markers[key].freq = null;
+    markers[key].time = null;
+    if (markers[key].el) markers[key].el.style.display = 'none';
+    if (key === 'start') startTime = null;
+    if (key === 'end') endTime = null;
+    tabData[currentTab].inputs[key] = '';
+    tabData[currentTab].markers[key].freq = null;
+    tabData[currentTab].markers[key].time = null;
+    tabData[currentTab].startTime = startTime;
+    tabData[currentTab].endTime = endTime;
+    updateDerived();
+    updateMarkers();
+  }
+
+  const resetButtons = panel.querySelectorAll('.autoid-marker[data-key]');
+  resetButtons.forEach(btn => {
+    const key = btn.dataset.key;
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      resetField(key);
+    });
+  });
+
   function updateDerived() {
     const high = parseFloat(inputs.high.value);
     const low = parseFloat(inputs.low.value);

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -143,7 +143,9 @@
           <div class="autoid-field">
             <input id="startFreqInput" class="autoid-input" type="text" readonly>
             <span class="autoid-unit">kHz</span>
-            <i class="fa-solid fa-xmark autoid-marker marker-start"></i>
+            <button class="autoid-marker marker-start" data-key="start" title="Reset Start freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
         </div>
         <div class="autoid-row">
@@ -151,7 +153,9 @@
           <div class="autoid-field">
             <input id="endFreqInput" class="autoid-input" type="text" readonly>
             <span class="autoid-unit">kHz</span>
-            <i class="fa-solid fa-xmark autoid-marker marker-end"></i>
+            <button class="autoid-marker marker-end" data-key="end" title="Reset End freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
         </div>
         <div class="autoid-row">
@@ -159,7 +163,9 @@
           <div class="autoid-field">
             <input id="highFreqInput" class="autoid-input" type="text" readonly>
             <span class="autoid-unit">kHz</span>
-            <i class="fa-solid fa-xmark autoid-marker marker-high"></i>
+            <button class="autoid-marker marker-high" data-key="high" title="Reset High freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
         </div>
         <div class="autoid-row">
@@ -167,7 +173,9 @@
           <div class="autoid-field">
             <input id="lowFreqInput" class="autoid-input" type="text" readonly>
             <span class="autoid-unit">kHz</span>
-            <i class="fa-solid fa-xmark autoid-marker marker-low"></i>
+            <button class="autoid-marker marker-low" data-key="low" title="Reset Low freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
         </div>
         <div class="autoid-row">
@@ -175,7 +183,9 @@
           <div class="autoid-field">
             <input id="kneeFreqInput" class="autoid-input" type="text" readonly>
             <span class="autoid-unit">kHz</span>
-            <i class="fa-solid fa-xmark autoid-marker marker-knee"></i>
+            <button class="autoid-marker marker-knee" data-key="knee" title="Reset Knee freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
         </div>
         <div class="autoid-row">
@@ -183,7 +193,9 @@
           <div class="autoid-field">
             <input id="heelFreqInput" class="autoid-input" type="text" readonly>
             <span class="autoid-unit">kHz</span>
-            <i class="fa-solid fa-xmark autoid-marker marker-heel"></i>
+            <button class="autoid-marker marker-heel" data-key="heel" title="Reset Heel freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
           </div>
         </div>
         <div class="autoid-row">

--- a/style.css
+++ b/style.css
@@ -683,6 +683,10 @@ input[type="file"]:hover {
 
 .autoid-marker {
   margin-left: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
 }
 
 .freq-marker {


### PR DESCRIPTION
## Summary
- convert Auto ID input clear icons into clickable buttons
- style Auto ID reset buttons
- add JS logic to reset individual Auto ID fields and markers

## Testing
- `node -c modules/autoIdPanel.js` *(fails: command has no output)*

------
https://chatgpt.com/codex/tasks/task_e_687ddf160698832a9c0133e6ed327765