### PR TITLE
Disable text selection globally

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,6 +7,14 @@ html, body {
   font-family: 'Noto Sans HK', sans-serif;
 }
 
+/* Disable text selection globally */
+* {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
 /* === Viewer 結構 === */
 #viewer-wrapper {
   position: relative;


### PR DESCRIPTION
## Summary
- prevent text selection across the whole interface using CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687de06a31e8832a868b36f39d8da1e7