### PR TITLE
Add draggable popup for Auto ID panel

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -14,6 +14,8 @@ export function initAutoIdPanel({
 } = {}) {
   const btn = document.getElementById(buttonId);
   const panel = document.getElementById(panelId);
+  const dragBar = panel.querySelector('.popup-drag-bar');
+  const closeBtn = panel.querySelector('.popup-close-btn');
   const viewer = document.getElementById(viewerId);
   const container = document.getElementById(containerId);
   const overlay = document.getElementById(overlayId);
@@ -40,9 +42,39 @@ export function initAutoIdPanel({
 
   if (!btn || !panel || !viewer) return;
 
-  btn.addEventListener('click', () => {
-    const isOpen = panel.classList.toggle('open');
-    document.body.classList.toggle('autoid-open', isOpen);
+  function togglePanel() {
+    const isVisible = panel.style.display === 'block';
+    panel.style.display = isVisible ? 'none' : 'block';
+    document.body.classList.toggle('autoid-open', !isVisible);
+  }
+
+  btn.addEventListener('click', togglePanel);
+  closeBtn?.addEventListener('click', togglePanel);
+
+  let dragging = false;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  function onDrag(e) {
+    if (!dragging) return;
+    panel.style.left = `${e.clientX - offsetX}px`;
+    panel.style.top = `${e.clientY - offsetY}px`;
+  }
+
+  function stopDrag() {
+    dragging = false;
+    document.removeEventListener('mousemove', onDrag);
+    refreshHover();
+  }
+
+  dragBar?.addEventListener('mousedown', (e) => {
+    dragging = true;
+    offsetX = e.clientX - panel.offsetLeft;
+    offsetY = e.clientY - panel.offsetTop;
+    hideHover();
+    document.addEventListener('mousemove', onDrag, { passive: true });
+    document.addEventListener('mouseup', stopDrag, { once: true });
+    e.preventDefault();
   });
 
   resetTabBtn?.addEventListener('click', resetCurrentTab);

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -116,12 +116,10 @@
           </label>
         </label>
       </div>
-      <div id="auto-id-panel">
-        <div class="panel-title">
-          <span>Auto ID Panel</span>
-          <button id="autoIdTabResetBtn" class="panel-reset-btn" title="Reset active tab">
-            <i class="fa-solid fa-rotate-left"></i>
-          </button>
+      <div id="auto-id-panel" class="map-popup">
+        <div class="popup-drag-bar">
+          <span class="popup-title">Auto ID Panel</span>
+          <button class="popup-close-btn" title="Close">&times;</button>
         </div>
         <div class="autoid-body">
           <div id="autoid-tabs"></div>
@@ -210,6 +208,9 @@
           <div class="autoid-field">
             <span id="durationVal">-</span>
             <span class="autoid-unit">ms</span>
+            <button id="autoIdTabResetBtn" class="panel-reset-btn" title="Reset active tab">
+              <i class="fa-solid fa-rotate-left"></i>
+            </button>
           </div>
         </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -586,43 +586,16 @@ input[type="file"]:hover {
 }
 
 #auto-id-panel {
-  position: absolute;
-  left: 50%;
-  top: calc(100% + 30px);
-  transform: translateX(-50%) scale(0.9);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 12px;
+  display: none;
   width: 400px;
-  background-color: #fff;
-  border-radius: 20px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  border: 1px solid #eee;
-  font-family: 'Noto Sans HK', sans-serif;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-#auto-id-panel.open {
-  opacity: 1;
-  pointer-events: auto;
-  z-index: 100;
-}
-
-#auto-id-panel .panel-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-weight: bold;
-  margin-bottom: 4px;
+  height: auto;
 }
 
 #auto-id-panel .panel-reset-btn {
   background: none;
   border: none;
   cursor: pointer;
+  margin-left: auto;
 }
 
 #auto-id-panel .panel-reset-btn i {


### PR DESCRIPTION
## Summary
- convert Auto ID panel into a popup window like the map popup
- support dragging and closing of the Auto ID popup
- move reset button to duration row
- style Auto ID popup with map popup styles

## Testing
- `node --check modules/autoIdPanel.js`
- `node --check main.js`
- `node --check modules/mapPopup.js`


------
https://chatgpt.com/codex/tasks/task_e_687e0a131fa4832aa51fc94acd3c334f