### PR TITLE
Disable knee and heel when CF call selected

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -80,9 +80,7 @@ export function initAutoIdPanel({
   resetTabBtn?.addEventListener('click', resetCurrentTab);
 
   const callTypeDropdown = initDropdown('callTypeInput', ['CF-FM','FM-CF-FM','FM','FM-QCF','QCF']);
-  callTypeDropdown.select(0);
   const harmonicDropdown = initDropdown('harmonicInput', ['0','1','2','3']);
-  harmonicDropdown.select(0);
   if (tabsContainer) {
     for (let i = 0; i < TAB_COUNT; i++) {
       const t = document.createElement("button");
@@ -167,7 +165,6 @@ export function initAutoIdPanel({
   }
 
   setMarkerInteractivity(true);
-  loadTab(0);
 
   Object.entries(inputs).forEach(([key, el]) => {
     if (!el) return;
@@ -201,14 +198,31 @@ export function initAutoIdPanel({
     updateMarkers();
   }
 
-  const resetButtons = panel.querySelectorAll('.autoid-marker[data-key]');
-  resetButtons.forEach(btn => {
+  const resetButtons = {};
+  panel.querySelectorAll('.autoid-marker[data-key]').forEach(btn => {
     const key = btn.dataset.key;
+    resetButtons[key] = btn;
     btn.addEventListener('click', (e) => {
       e.preventDefault();
       resetField(key);
     });
   });
+
+  function handleCallTypeChange(value, idx) {
+    const disable = idx <= 1;
+    ['knee', 'heel'].forEach(k => {
+      if (!inputs[k]) return;
+      inputs[k].disabled = disable;
+      const btn = resetButtons[k];
+      if (btn) btn.disabled = disable;
+      if (disable) resetField(k);
+    });
+  }
+
+  callTypeDropdown.onChange = handleCallTypeChange;
+  harmonicDropdown.select(0);
+  callTypeDropdown.select(0);
+  loadTab(0);
 
   function updateDerived() {
     const high = parseFloat(inputs.high.value);

--- a/style.css
+++ b/style.css
@@ -624,6 +624,11 @@ input[type="file"]:hover {
   height: 23px;
   padding: 2px 6px;
 }
+#auto-id-panel .autoid-input:disabled {
+  background-color: #eee;
+  color: #aaa;
+  cursor: not-allowed;
+}
 
 #auto-id-panel .autoid-unit {
   margin-left: 2px;
@@ -674,6 +679,10 @@ input[type="file"]:hover {
   border: none;
   cursor: pointer;
   padding: 0;
+}
+#auto-id-panel .autoid-marker:disabled {
+  color: #aaa;
+  cursor: not-allowed;
 }
 
 .freq-marker {


### PR DESCRIPTION
## Summary
- disable Knee and Heel fields when CF call types are selected
- grey out disabled fields and marker buttons

## Testing
- `node --check modules/autoIdPanel.js`

------
https://chatgpt.com/codex/tasks/task_e_687e106fe2bc832a8e9ef1aaa8018106