### PR TITLE
Fix Auto ID panel layering

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -19,6 +19,11 @@ export function initAutoIdPanel({
   const viewer = document.getElementById(viewerId);
   const container = document.getElementById(containerId);
   const overlay = document.getElementById(overlayId);
+
+  const layout = document.getElementById('layout');
+  if (layout && panel && panel.parentElement !== layout) {
+    layout.appendChild(panel);
+  }
   const resetTabBtn = document.getElementById('autoIdTabResetBtn');
   const tabsContainer = document.getElementById("autoid-tabs");
   const tabs = [];


### PR DESCRIPTION
## Summary
- move Auto ID panel outside of `#mainarea` so it behaves like other popups
- restore `overflow-x: hidden` on `#mainarea`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e166cad24832aa662dd61aaceb3b9