### PR TITLE
Add Hong Kong auto ID example

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -1,4 +1,5 @@
-import { initDropdown } from './dropdown.js';
+import { initDropdown } from "./dropdown.js";
+import { autoIdHK } from "./autoid_HK.js";
 
 export function initAutoIdPanel({
   buttonId = 'autoIdBtn',
@@ -412,8 +413,19 @@ export function initAutoIdPanel({
   function showPlaceholderResult() {
     if (resultEl) resultEl.textContent = '-';
   }
+  function runPulseId() {
+    const callType = callTypeDropdown.items[callTypeDropdown.selectedIndex];
+    const high = parseFloat(inputs.high.value);
+    if (isNaN(high)) {
+      if (resultEl) resultEl.textContent = "-";
+      return;
+    }
+    const res = autoIdHK({ callType, highFreq: high });
+    if (resultEl) resultEl.textContent = res;
+  }
 
-  pulseIdBtn?.addEventListener('click', showPlaceholderResult);
+
+  pulseIdBtn?.addEventListener('click', runPulseId);
   sequenceIdBtn?.addEventListener('click', showPlaceholderResult);
 
   return { updateMarkers, reset, resetCurrentTab };

--- a/modules/autoid_HK.js
+++ b/modules/autoid_HK.js
@@ -1,0 +1,18 @@
+// modules/autoid_HK.js
+
+export function autoIdHK({ callType, highFreq }) {
+  let result = '-';
+  if (callType === 'CF-FM') {
+    if (highFreq >= 120 && highFreq <= 130) result = 'Hipposideros gentilis';
+    else if (highFreq >= 60 && highFreq <= 70) result = 'Hipposideros armiger';
+    else result = 'Hipposideros sp.';
+  } else if (callType === 'FM-CF-FM') {
+    if (highFreq >= 100 && highFreq <= 110) result = 'Rhinolophus pusillus';
+    else if (highFreq >= 75 && highFreq <= 85) result = 'Rhinolophus sinicus';
+    else if (highFreq >= 65 && highFreq <= 75) result = 'Rhinolophus affinis';
+    else result = 'Rhinolophus sp.';
+  } else if (callType === 'FM' || callType === 'FM-QCF' || callType === 'QCF') {
+    result = 'TBC';
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- add Hong Kong auto ID algorithm
- hook Pulse ID button to run new logic

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687e30dc0b18832ab8de440add06f9ec