### PR TITLE
Format Auto ID results as italics

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -410,6 +410,26 @@ export function initAutoIdPanel({
 
   viewer.addEventListener('scroll', updateMarkers);
 
+  function formatSpeciesResult(res) {
+    const italicSpecies = new Set([
+      'Hipposideros armiger',
+      'Hipposideros gentilis',
+      'Rhinolophus affinis',
+      'Rhinolophus pusillus',
+      'Rhinolophus sinicus'
+    ]);
+    if (italicSpecies.has(res)) {
+      return `<i>${res}</i>`;
+    }
+    if (res === 'Hipposideros sp.') {
+      return '<i>Hipposideros</i> sp.';
+    }
+    if (res === 'Rhinolophus sp.') {
+      return '<i>Rhinolophus</i> sp.';
+    }
+    return res;
+  }
+
   function showPlaceholderResult() {
     if (resultEl) resultEl.textContent = '-';
   }
@@ -421,7 +441,7 @@ export function initAutoIdPanel({
       return;
     }
     const res = autoIdHK({ callType, highFreq: high });
-    if (resultEl) resultEl.textContent = res;
+    if (resultEl) resultEl.innerHTML = formatSpeciesResult(res);
   }
 
 


### PR DESCRIPTION
## Summary
- show Auto ID panel results with scientific names in italics
- italicize only genus for generic `sp.` results

## Testing
- `node --check modules/autoIdPanel.js`
- `node --check modules/autoid_HK.js`

------
https://chatgpt.com/codex/tasks/task_e_687e346f58a8832aa112ee2ef88c26ef