### PR TITLE
Refine Auto ID panel layout

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -219,6 +219,8 @@
         <div class="autoid-action-row">
           <button id="pulseIdBtn" class="autoid-action-btn">Pulse ID</button>
           <button id="sequenceIdBtn" class="autoid-action-btn">Sequence ID</button>
+        </div>
+        <div class="autoid-result-row">
           <span class="autoid-result-label">Result: <span id="autoIdResult">-</span></span>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -678,8 +678,15 @@ input[type="file"]:hover {
 .autoid-action-row {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   margin-top: 6px;
+}
+
+.autoid-result-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 4px;
 }
 
 .autoid-action-btn {
@@ -698,7 +705,6 @@ input[type="file"]:hover {
 }
 
 .autoid-result-label {
-  margin-left: auto;
   font-size: 14px;
 }
 


### PR DESCRIPTION
## Summary
- center align the Pulse ID and Sequence ID buttons
- move the Auto ID result to its own row

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_687e495c6d78832a855552ad81815fd9