### PR TITLE
Add QCF bandwidth warning

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -112,6 +112,16 @@ export function initAutoIdPanel({
   const pulseIdBtn = document.getElementById('pulseIdBtn');
   const sequenceIdBtn = document.getElementById('sequenceIdBtn');
   const resultEl = document.getElementById('autoIdResult');
+  const bandwidthWarning = document.getElementById('bandwidth-warning');
+
+  function updateBandwidthWarning(bw) {
+    const callType = callTypeDropdown.items[callTypeDropdown.selectedIndex];
+    const show = callType === 'QCF' && bw != null && bw > 5;
+    ['high', 'low'].forEach(k => {
+      if (inputs[k]) inputs[k].classList.toggle('invalid', show);
+    });
+    if (bandwidthWarning) bandwidthWarning.style.display = show ? 'flex' : 'none';
+  }
 
   const markerColors = {
     start: '#e74c3c',
@@ -226,6 +236,7 @@ export function initAutoIdPanel({
       if (btn) btn.disabled = disable;
       if (disable) resetField(k);
     });
+    updateDerived();
   }
 
   callTypeDropdown.onChange = handleCallTypeChange;
@@ -236,14 +247,19 @@ export function initAutoIdPanel({
   function updateDerived() {
     const high = parseFloat(inputs.high.value);
     const low = parseFloat(inputs.low.value);
+    let bandwidth = null;
     if (!isNaN(high) && !isNaN(low)) {
-      bandwidthEl.textContent = (high - low).toFixed(1);
+      bandwidth = high - low;
+      bandwidthEl.textContent = bandwidth.toFixed(1);
+    } else {
+      bandwidthEl.textContent = '-';
     }
     if (startTime != null && endTime != null) {
       durationEl.textContent = ((endTime - startTime) * 1000).toFixed(1);
     } else if (markers.high.time != null && markers.low.time != null) {
       durationEl.textContent = ((markers.low.time - markers.high.time) * 1000).toFixed(1);
     }
+    updateBandwidthWarning(bandwidth);
   }
 
   function createMarkerEl(key, tabIdx) {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -121,6 +121,9 @@
           <span class="popup-title">Auto ID Panel</span>
           <button class="popup-close-btn" title="Close">&times;</button>
         </div>
+        <div id="bandwidth-warning" class="coord-scale-wrapper" style="display:none; top:40px; left:50%; transform:translateX(-50%);">
+          Bandwidth should be &lt;5khz for QCF call type
+        </div>
         <div class="autoid-body">
           <div class="autoid-tabs-row">
             <div id="autoid-tabs"></div>

--- a/style.css
+++ b/style.css
@@ -632,6 +632,9 @@ input[type="file"]:hover {
   color: #aaa;
   cursor: not-allowed;
 }
+#auto-id-panel .autoid-input.invalid {
+  background-color: #fdd;
+}
 
 #auto-id-panel .autoid-unit {
   margin-left: 2px;


### PR DESCRIPTION
## Summary
- highlight frequency inputs when QCF bandwidth >5kHz
- show bandwidth warning message in Auto ID panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e4f8a5760832ab751e34b15edca16