### PR TITLE
Fix auto ID panel duration reset

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -258,6 +258,8 @@ export function initAutoIdPanel({
       durationEl.textContent = ((endTime - startTime) * 1000).toFixed(1);
     } else if (markers.high.time != null && markers.low.time != null) {
       durationEl.textContent = ((markers.low.time - markers.high.time) * 1000).toFixed(1);
+    } else {
+      durationEl.textContent = '-';
     }
     updateBandwidthWarning(bandwidth);
   }


### PR DESCRIPTION
## Summary
- recompute and clear duration when marker reset clears times

## Testing
- `pre-commit` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_687e55996cc0832aba3743ed051b8519