### PR TITLE
Move bandwidth warning styles to CSS

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -121,7 +121,7 @@
           <span class="popup-title">Auto ID Panel</span>
           <button class="popup-close-btn" title="Close">&times;</button>
         </div>
-        <div id="bandwidth-warning" class="coord-scale-wrapper" style="display:none; top:40px; left:50%; height: 20px; width: max-content; transform:translateX(-50%);">
+        <div id="bandwidth-warning" class="coord-scale-wrapper">
           Bandwidth should be &lt;5khz for QCF call type
         </div>
         <div class="autoid-body">

--- a/style.css
+++ b/style.css
@@ -1318,6 +1318,18 @@ input.tag-button.editing {
   background: transparent;
 }
 
+#bandwidth-warning {
+  display: none;
+  top: 40px;
+  left: 50%;
+  bottom: auto;
+  height: 20px;
+  width: max-content;
+  transform: translateX(-50%);
+  background: rgb(16 16 16 / 60%);
+  color: white;
+}
+
 .map-marker-other i{
   font-size: 28px;
   line-height: 28px;


### PR DESCRIPTION
## Summary
- remove inline style from bandwidth warning div
- create `#bandwidth-warning` CSS rule with display, positioning and colors

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687e60559720832a9c595a2eee79facb