### PR TITLE
Add freq order validation

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -113,14 +113,18 @@ export function initAutoIdPanel({
   const sequenceIdBtn = document.getElementById('sequenceIdBtn');
   const resultEl = document.getElementById('autoIdResult');
   const bandwidthWarning = document.getElementById('bandwidth-warning');
+  const freqOrderWarning = document.getElementById('freq-order-warning');
 
-  function updateBandwidthWarning(bw) {
+  function updateWarnings(high, low, bw) {
     const callType = callTypeDropdown.items[callTypeDropdown.selectedIndex];
-    const show = callType === 'QCF' && bw != null && bw > 5;
+    const showBandwidth = callType === 'QCF' && bw != null && bw > 5;
+    const showOrder = !isNaN(high) && !isNaN(low) && low > high;
+    const invalid = showBandwidth || showOrder;
     ['high', 'low'].forEach(k => {
-      if (inputs[k]) inputs[k].classList.toggle('invalid', show);
+      if (inputs[k]) inputs[k].classList.toggle('invalid', invalid);
     });
-    if (bandwidthWarning) bandwidthWarning.style.display = show ? 'flex' : 'none';
+    if (bandwidthWarning) bandwidthWarning.style.display = showBandwidth ? 'flex' : 'none';
+    if (freqOrderWarning) freqOrderWarning.style.display = showOrder ? 'flex' : 'none';
   }
 
   const markerColors = {
@@ -261,7 +265,7 @@ export function initAutoIdPanel({
     } else {
       durationEl.textContent = '-';
     }
-    updateBandwidthWarning(bandwidth);
+    updateWarnings(high, low, bandwidth);
   }
 
   function createMarkerEl(key, tabIdx) {

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -124,6 +124,9 @@
         <div id="bandwidth-warning" class="coord-scale-wrapper">
           Bandwidth should be &lt;5khz for QCF call type
         </div>
+        <div id="freq-order-warning" class="coord-scale-wrapper">
+          Highest frequency should be higher than lowest frequency
+        </div>
         <div class="autoid-body">
           <div class="autoid-tabs-row">
             <div id="autoid-tabs"></div>

--- a/style.css
+++ b/style.css
@@ -1330,6 +1330,18 @@ input.tag-button.editing {
   color: white;
 }
 
+#freq-order-warning {
+  display: none;
+  top: 65px;
+  left: 50%;
+  bottom: auto;
+  height: 20px;
+  width: max-content;
+  transform: translateX(-50%);
+  background: rgb(16 16 16 / 60%);
+  color: white;
+}
+
 .map-marker-other i{
   font-size: 28px;
   line-height: 28px;


### PR DESCRIPTION
## Summary
- flag low/high frequency input mismatch in Auto ID panel
- style and display a new warning box when low frequency is greater than high frequency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e631df41c832ab89f1335a94e0dca