### PR TITLE
Fix Auto ID drag shows hover lines

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -70,7 +70,7 @@ export function initAutoIdPanel({
   function stopDrag() {
     dragging = false;
     document.removeEventListener('mousemove', onDrag);
-    refreshHover();
+    hideHover();
   }
 
   dragBar?.addEventListener('mousedown', (e) => {


### PR DESCRIPTION
## Summary
- prevent hover lines reappearing when Auto ID panel drag stops

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f073683ec832abf4bc1cde161a85d