### PR TITLE
Implement AutoID frequency context menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -23,6 +23,7 @@ import { initTagControl } from './modules/tagControl.js';
 import { initDropdown } from './modules/dropdown.js';
 import { showMessageBox } from './modules/messageBox.js';
 import { initAutoIdPanel } from './modules/autoIdPanel.js';
+import { initFreqContextMenu } from './modules/freqContextMenu.js';
 import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
 const spectrogramHeight = 800;
@@ -55,6 +56,7 @@ let currentOverlap = 'auto';
 let overlapWarningShown = false;
 let freqHoverControl = null;
 let autoIdControl = null;
+let freqMenuControl = null;
 const sampleRateBtn = document.getElementById('sampleRateInput');
 let selectionExpandMode = false;
 let expandHistory = [];
@@ -913,6 +915,21 @@ autoIdControl = initAutoIdPanel({
   getFreqRange: () => ({ min: currentFreqMin, max: currentFreqMax }),
   hideHover: () => freqHoverControl?.hideHover(),
   refreshHover: () => freqHoverControl?.refreshHover()
+});
+freqMenuControl = initFreqContextMenu({
+  viewerId: 'viewer-container',
+  containerId: 'spectrogram-only',
+  spectrogramHeight,
+  getDuration,
+  getFreqRange: () => ({ min: currentFreqMin, max: currentFreqMax }),
+  autoId: autoIdControl
+});
+document.addEventListener('autoid-open', () => {
+  freqHoverControl?.setPersistentLinesEnabled(false);
+});
+document.addEventListener('autoid-close', () => {
+  freqHoverControl?.setPersistentLinesEnabled(true);
+  freqMenuControl?.hide();
 });
 document.addEventListener('hide-spectrogram-hover', () => {
   freqHoverControl?.hideHover();

--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -52,6 +52,7 @@ export function initAutoIdPanel({
     const isVisible = panel.style.display === 'block';
     panel.style.display = isVisible ? 'none' : 'block';
     document.body.classList.toggle('autoid-open', !isVisible);
+    document.dispatchEvent(new Event(isVisible ? 'autoid-close' : 'autoid-open'));
   }
 
   btn.addEventListener('click', togglePanel);
@@ -341,6 +342,26 @@ export function initAutoIdPanel({
     refreshHover();
   }
 
+  function setMarkerAt(key, freq, time) {
+    const input = inputs[key];
+    if (!input) return;
+    input.value = freq.toFixed(1);
+    input.dataset.time = time;
+    markers[key].freq = freq;
+    markers[key].time = time;
+    if (key === 'start') startTime = time;
+    if (key === 'end') endTime = time;
+    tabData[currentTab].startTime = startTime;
+    tabData[currentTab].endTime = endTime;
+    updateDerived();
+    updateMarkers();
+  }
+
+  function isFieldEnabled(key) {
+    const input = inputs[key];
+    return input && !input.disabled;
+  }
+
   function resetTabData(tab) {
     tab.callType = 0;
     tab.harmonic = 0;
@@ -477,5 +498,14 @@ export function initAutoIdPanel({
   pulseIdBtn?.addEventListener('click', runPulseId);
   sequenceIdBtn?.addEventListener('click', showPlaceholderResult);
 
-  return { updateMarkers, reset, resetCurrentTab };
+  return {
+    updateMarkers,
+    reset,
+    resetCurrentTab,
+    setMarkerAt,
+    isFieldEnabled,
+    getFreqRange,
+    getDuration: () => getDuration(),
+    spectrogramHeight
+  };
 }

--- a/modules/freqContextMenu.js
+++ b/modules/freqContextMenu.js
@@ -1,0 +1,82 @@
+export function initFreqContextMenu({
+  viewerId,
+  containerId = 'spectrogram-only',
+  spectrogramHeight = 800,
+  getDuration,
+  getFreqRange,
+  autoId
+}) {
+  const viewer = document.getElementById(viewerId);
+  const container = document.getElementById(containerId);
+  if (!viewer) return null;
+  const menu = document.createElement('div');
+  menu.id = 'freq-context-menu';
+  menu.className = 'freq-context-menu';
+  menu.style.display = 'none';
+  const labels = {
+    start: 'Start freq.',
+    end: 'End freq.',
+    high: 'High freq.',
+    low: 'Low freq.',
+    knee: 'Knee freq.',
+    heel: 'Heel freq.'
+  };
+  const keys = Object.keys(labels);
+  keys.forEach(key => {
+    const item = document.createElement('div');
+    item.className = 'freq-menu-item';
+    item.textContent = labels[key];
+    item.dataset.key = key;
+    item.addEventListener('click', () => {
+      if (item.classList.contains('disabled')) return;
+      hide();
+      if (autoId && typeof autoId.setMarkerAt === 'function') {
+        autoId.setMarkerAt(key, currentFreq, currentTime);
+      }
+    });
+    menu.appendChild(item);
+  });
+  document.body.appendChild(menu);
+
+  let currentFreq = 0;
+  let currentTime = 0;
+
+  function show(clientX, clientY, freq, time) {
+    currentFreq = freq;
+    currentTime = time;
+    keys.forEach(k => {
+      const el = menu.querySelector(`[data-key="${k}"]`);
+      const enabled = !autoId || (typeof autoId.isFieldEnabled === 'function' && autoId.isFieldEnabled(k));
+      el.classList.toggle('disabled', !enabled);
+    });
+    menu.style.left = `${clientX}px`;
+    menu.style.top = `${clientY}px`;
+    menu.style.display = 'block';
+  }
+
+  function hide() {
+    menu.style.display = 'none';
+  }
+
+  viewer.addEventListener('contextmenu', (e) => {
+    if (!document.body.classList.contains('autoid-open')) return;
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const rect = viewer.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const scrollLeft = viewer.scrollLeft || 0;
+    const { min, max } = getFreqRange();
+    const freq = (1 - y / spectrogramHeight) * (max - min) + min;
+    const time = ((x + scrollLeft) / container.scrollWidth) * getDuration();
+    show(e.clientX, e.clientY, freq, time);
+  });
+
+  document.addEventListener('mousedown', (ev) => {
+    if (ev.button !== 0) return;
+    if (menu.style.display === 'none') return;
+    if (!menu.contains(ev.target)) hide();
+  });
+
+  return { hide };
+}

--- a/style.css
+++ b/style.css
@@ -1697,3 +1697,39 @@ input.tag-button.editing {
   display: inline-flex;
   width: 30px;
 }
+
+/* === Frequency Context Menu === */
+.freq-context-menu {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  padding: 4px 0;
+  z-index: 1000;
+  font-family: 'Noto Sans HK', sans-serif;
+  user-select: none;
+  display: none;
+}
+
+.freq-menu-item {
+  padding: 6px 20px;
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 14px;
+}
+
+.freq-menu-item:hover {
+  background-color: rgba(0,0,0,0.1);
+}
+
+.freq-menu-item.disabled {
+  color: #aaa;
+  cursor: default;
+}
+
+.freq-menu-item.disabled:hover {
+  background-color: transparent;
+}


### PR DESCRIPTION
## Summary
- notify others when Auto ID panel opens/closes
- expose marker helper functions in Auto ID panel
- add frequency context menu module
- style frequency context menu with translucent look
- initialise context menu and handle Auto ID open/close

## Testing
- `node --check modules/freqContextMenu.js`
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_687f0a9844e0832ababd36abe6f8761c