### PR TITLE
Add CF start/end freq fields with dynamic hiding

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -37,7 +37,16 @@ export function initAutoIdPanel({
   const tabData = Array.from({ length: TAB_COUNT }, () => ({
     callType: 3,
     harmonic: 0,
-    inputs: { start: "", end: "", high: "", low: "", knee: "", heel: "" },
+    inputs: {
+      start: "",
+      end: "",
+      high: "",
+      low: "",
+      knee: "",
+      heel: "",
+      cfStart: "",
+      cfEnd: ""
+    },
     startTime: null,
     endTime: null,
     markers: {
@@ -46,7 +55,9 @@ export function initAutoIdPanel({
       high: { el: null, freq: null, time: null },
       low: { el: null, freq: null, time: null },
       knee: { el: null, freq: null, time: null },
-      heel: { el: null, freq: null, time: null }
+      heel: { el: null, freq: null, time: null },
+      cfStart: { el: null, freq: null, time: null },
+      cfEnd: { el: null, freq: null, time: null }
     },
     line: null
   }));
@@ -113,6 +124,18 @@ export function initAutoIdPanel({
     low: document.getElementById('lowFreqInput'),
     knee: document.getElementById('kneeFreqInput'),
     heel: document.getElementById('heelFreqInput'),
+    cfStart: document.getElementById('cfStartFreqInput'),
+    cfEnd: document.getElementById('cfEndFreqInput'),
+  };
+  const rows = {
+    start: document.getElementById('startFreqRow'),
+    end: document.getElementById('endFreqRow'),
+    high: document.getElementById('highFreqRow'),
+    low: document.getElementById('lowFreqRow'),
+    knee: document.getElementById('kneeFreqRow'),
+    heel: document.getElementById('heelFreqRow'),
+    cfStart: document.getElementById('cfStartFreqRow'),
+    cfEnd: document.getElementById('cfEndFreqRow'),
   };
   const bandwidthEl = document.getElementById('bandwidthVal');
   const durationEl = document.getElementById('durationVal');
@@ -140,7 +163,9 @@ export function initAutoIdPanel({
     high: '#3498db',
     low: '#9b59b6',
     knee: '#f39c12',
-    heel: '#16a085'
+    heel: '#16a085',
+    cfStart: '#e67e22',
+    cfEnd: '#1abc9c'
   };
 
   let markers = tabData[currentTab].markers;
@@ -238,15 +263,26 @@ export function initAutoIdPanel({
     });
   });
 
+  function toggleRow(key, show) {
+    const row = rows[key];
+    if (!row) return;
+    row.style.display = show ? 'flex' : 'none';
+    if (inputs[key]) inputs[key].disabled = !show;
+    const btn = resetButtons[key];
+    if (btn) btn.disabled = !show;
+    if (!show) resetField(key);
+  }
+
   function handleCallTypeChange(value, idx) {
-    const disable = ['CF-FM', 'FM-CF-FM', 'QCF'].includes(value);
-    ['knee', 'heel'].forEach(k => {
-      if (!inputs[k]) return;
-      inputs[k].disabled = disable;
-      const btn = resetButtons[k];
-      if (btn) btn.disabled = disable;
-      if (disable) resetField(k);
-    });
+    const hideHighLow = ['CF-FM', 'FM-CF-FM'].includes(value);
+    const hideKneeHeel = ['CF-FM', 'FM-CF-FM', 'QCF'].includes(value);
+    const hideCf = ['QCF', 'FM-QCF', 'FM'].includes(value);
+    toggleRow('high', !hideHighLow);
+    toggleRow('low', !hideHighLow);
+    toggleRow('knee', !hideKneeHeel);
+    toggleRow('heel', !hideKneeHeel);
+    toggleRow('cfStart', !hideCf);
+    toggleRow('cfEnd', !hideCf);
     tabData[currentTab].callType = idx;
     updateDerived();
     updateLines();
@@ -258,10 +294,20 @@ export function initAutoIdPanel({
   loadTab(0);
 
   function updateDerived() {
+    const callType = callTypeDropdown.items[callTypeDropdown.selectedIndex];
     const high = parseFloat(inputs.high.value);
     const low = parseFloat(inputs.low.value);
+    const cfStartVal = parseFloat(inputs.cfStart.value);
+    const endVal = parseFloat(inputs.end.value);
     let bandwidth = null;
-    if (!isNaN(high) && !isNaN(low)) {
+    if (['FM-CF-FM', 'CF-FM'].includes(callType)) {
+      if (!isNaN(cfStartVal) && !isNaN(endVal)) {
+        bandwidth = cfStartVal - endVal;
+        bandwidthEl.textContent = bandwidth.toFixed(1);
+      } else {
+        bandwidthEl.textContent = '-';
+      }
+    } else if (!isNaN(high) && !isNaN(low)) {
       bandwidth = high - low;
       bandwidthEl.textContent = bandwidth.toFixed(1);
     } else {

--- a/modules/freqContextMenu.js
+++ b/modules/freqContextMenu.js
@@ -19,7 +19,9 @@ export function initFreqContextMenu({
     high: 'High freq.',
     low: 'Low freq.',
     knee: 'Knee freq.',
-    heel: 'Heel freq.'
+    heel: 'Heel freq.',
+    cfStart: 'CF start',
+    cfEnd: 'CF end'
   };
   const keys = Object.keys(labels);
   keys.forEach(key => {
@@ -48,6 +50,7 @@ export function initFreqContextMenu({
       const el = menu.querySelector(`[data-key="${k}"]`);
       const enabled = !autoId || (typeof autoId.isFieldEnabled === 'function' && autoId.isFieldEnabled(k));
       el.classList.toggle('disabled', !enabled);
+      el.style.display = enabled ? 'block' : 'none';
     });
     menu.style.left = `${clientX}px`;
     menu.style.top = `${clientY}px`;

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -135,19 +135,39 @@
             </button>
           </div>
           <div id="autoid-fields">
-        <div class="autoid-row">
+        <div class="autoid-row" id="callTypeRow">
           <span class="autoid-label">Call type:</span>
           <div class="autoid-field">
             <button id="callTypeInput" class="dropdown-button">CF-FM</button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="harmonicRow">
           <span class="autoid-label">Harmonic:</span>
           <div class="autoid-field">
             <button id="harmonicInput" class="dropdown-button">0</button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="cfStartFreqRow">
+          <span class="autoid-label">CF start:</span>
+          <div class="autoid-field">
+            <input id="cfStartFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire CF Start Frequency">
+            <span class="autoid-unit">kHz</span>
+            <button class="autoid-marker marker-cfstart" data-key="cfStart" title="Reset CF start freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+          </div>
+        </div>
+        <div class="autoid-row" id="cfEndFreqRow">
+          <span class="autoid-label">CF end:</span>
+          <div class="autoid-field">
+            <input id="cfEndFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire CF End Frequency">
+            <span class="autoid-unit">kHz</span>
+            <button class="autoid-marker marker-cfend" data-key="cfEnd" title="Reset CF end freq.">
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+          </div>
+        </div>
+        <div class="autoid-row" id="startFreqRow">
           <span class="autoid-label">Start freq.:</span>
           <div class="autoid-field">
             <input id="startFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Start Frequency">
@@ -157,7 +177,7 @@
             </button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="endFreqRow">
           <span class="autoid-label">End freq.:</span>
           <div class="autoid-field">
             <input id="endFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire End Frequency">
@@ -167,7 +187,7 @@
             </button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="highFreqRow">
           <span class="autoid-label">High freq.:</span>
           <div class="autoid-field">
             <input id="highFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Highest Frequency">
@@ -177,7 +197,7 @@
             </button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="lowFreqRow">
           <span class="autoid-label">Low freq.:</span>
           <div class="autoid-field">
             <input id="lowFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Lowest Frequency">
@@ -187,7 +207,7 @@
             </button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="kneeFreqRow">
           <span class="autoid-label">Knee freq.:</span>
           <div class="autoid-field">
             <input id="kneeFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Knee Frequency">
@@ -197,7 +217,7 @@
             </button>
           </div>
         </div>
-        <div class="autoid-row">
+        <div class="autoid-row" id="heelFreqRow">
           <span class="autoid-label">Heel freq.:</span>
           <div class="autoid-field">
             <input id="heelFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Heel Frequency">

--- a/style.css
+++ b/style.css
@@ -756,6 +756,8 @@ body.markers-disabled .freq-marker {
 .marker-low { color: #9b59b6; }
 .marker-knee { color: #f39c12; }
 .marker-heel { color: #16a085; }
+.marker-cfstart { color: #e67e22; }
+.marker-cfend { color: #1abc9c; }
 
 /* === Sidebar Button === */
 .sidebar-button {


### PR DESCRIPTION
## Summary
- add CF start/end inputs in Auto ID panel
- show/hide frequency rows and context menu items based on call type
- compute bandwidth with CF start for CF-FM and FM-CF-FM calls
- add marker colors for new markers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f33a93d80832aad107e9792baa107