### PR TITLE
Fix freq context menu overflow

### DIFF
--- a/modules/freqContextMenu.js
+++ b/modules/freqContextMenu.js
@@ -52,9 +52,15 @@ export function initFreqContextMenu({
       el.classList.toggle('disabled', !enabled);
       el.style.display = enabled ? 'block' : 'none';
     });
+    menu.style.display = 'block';
     menu.style.left = `${clientX}px`;
     menu.style.top = `${clientY}px`;
-    menu.style.display = 'block';
+    const menuRect = menu.getBoundingClientRect();
+    const viewerRect = viewer.getBoundingClientRect();
+    if (menuRect.right > viewerRect.right) {
+      const newLeft = clientX - menuRect.width;
+      menu.style.left = `${Math.max(viewerRect.left, newLeft)}px`;
+    }
   }
 
   function hide() {


### PR DESCRIPTION
## Summary
- reposition frequency context menu if it would overflow past the spectrogram's right edge

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f9841f2ac832aba7d93133acc1905