### PR TITLE
Fix selection buttons near right edge

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -348,6 +348,21 @@ export function initFrequencyHover({
     sel.closeBtn = closeBtn;
     sel.expandBtn = expandBtn;
     sel.fitBtn = fitBtn;
+
+    repositionBtnGroup(sel);
+  }
+
+  function repositionBtnGroup(sel) {
+    if (!sel.btnGroup) return;
+    const group = sel.btnGroup;
+    group.style.left = '';
+    group.style.right = '-35px';
+    const groupRect = group.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    if (groupRect.right > containerRect.right) {
+      group.style.right = 'auto';
+      group.style.left = '-35px';
+    }
   }
 
   function enableResize(sel) {
@@ -521,6 +536,7 @@ export function initFrequencyHover({
       }
 
       updateTooltipValues(sel, left, top, width, height);
+      repositionBtnGroup(sel);
     });
   }
 


### PR DESCRIPTION
## Summary
- reposition the selection button group when it overflows the spectrogram
- remove the right style using `auto` when moving the group left

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f9f7c6914832aa40664d799b20b01