### PR TITLE
Fix selection resize boundary

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -447,11 +447,15 @@ export function initFrequencyHover({
 
         const viewerRect = viewer.getBoundingClientRect();
         const scrollLeft = viewer.scrollLeft || 0;
-        const mouseX = e.clientX - viewerRect.left + scrollLeft;
-        const mouseY = e.clientY - viewerRect.top;
+        let mouseX = e.clientX - viewerRect.left + scrollLeft;
+        let mouseY = e.clientY - viewerRect.top;
 
         const actualWidth = getDuration() * getZoomLevel();
         const freqRange = maxFrequency - minFrequency;
+
+        // Clamp to spectrogram bounds
+        mouseX = Math.min(Math.max(mouseX, 0), actualWidth);
+        mouseY = Math.min(Math.max(mouseY, 0), spectrogramHeight);
 
         if (lockedHorizontal === 'left') {
           let newStartTime = (mouseX / actualWidth) * getDuration();


### PR DESCRIPTION
## Summary
- avoid letting resize drag move selection outside spectrogram bounds

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_68804149a700832a93fa2d340473f537