### PR TITLE
Implement delayed validation for Auto ID

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -175,6 +175,7 @@ export function initAutoIdPanel({
   let endTime = null;
   let draggingKey = null;
   let markersEnabled = true;
+  let showValidation = false;
   function saveCurrentTab() {
     const data = tabData[currentTab];
     data.callType = callTypeDropdown.selectedIndex;
@@ -239,6 +240,7 @@ export function initAutoIdPanel({
     input.value = '';
     delete input.dataset.time;
     input.classList.remove('active-get');
+    input.classList.remove('invalid');
     markers[key].freq = null;
     markers[key].time = null;
     if (markers[key].el) markers[key].el.style.display = 'none';
@@ -251,6 +253,7 @@ export function initAutoIdPanel({
     tabData[currentTab].endTime = endTime;
     updateDerived();
     updateMarkers();
+    validateMandatoryInputs();
   }
 
   const resetButtons = {};
@@ -271,6 +274,7 @@ export function initAutoIdPanel({
     const btn = resetButtons[key];
     if (btn) btn.disabled = !show;
     if (!show) resetField(key);
+    validateMandatoryInputs();
   }
 
   function handleCallTypeChange(value, idx) {
@@ -286,6 +290,7 @@ export function initAutoIdPanel({
     tabData[currentTab].callType = idx;
     updateDerived();
     updateLines();
+    validateMandatoryInputs();
   }
 
   callTypeDropdown.onChange = handleCallTypeChange;
@@ -465,6 +470,7 @@ export function initAutoIdPanel({
     draggingKey = null;
     document.removeEventListener('mousemove', onMarkerDrag);
     refreshHover();
+    validateMandatoryInputs();
   }
 
   function setMarkerAt(key, freq, time) {
@@ -480,6 +486,7 @@ export function initAutoIdPanel({
     tabData[currentTab].endTime = endTime;
     updateDerived();
     updateMarkers();
+    validateMandatoryInputs();
   }
 
   function removeMarker(key) {
@@ -509,6 +516,7 @@ export function initAutoIdPanel({
   }
 
   function resetCurrentTab() {
+    showValidation = false;
     resetTabData(tabData[currentTab]);
     callTypeDropdown.select(3);
     harmonicDropdown.select(0);
@@ -517,6 +525,7 @@ export function initAutoIdPanel({
       el.value = "";
       delete el.dataset.time;
       el.classList.remove('active-get');
+      el.classList.remove('invalid');
     });
     bandwidthEl.textContent = '-';
     durationEl.textContent = '-';
@@ -528,6 +537,7 @@ export function initAutoIdPanel({
   }
 
   function reset() {
+    showValidation = false;
     tabData.forEach(d => {
       d.callType = 3;
       d.harmonic = 0;
@@ -547,6 +557,7 @@ export function initAutoIdPanel({
       el.value = "";
       delete el.dataset.time;
       el.classList.remove('active-get');
+      el.classList.remove('invalid');
     });
     bandwidthEl.textContent = '-';
     durationEl.textContent = '-';
@@ -613,27 +624,57 @@ export function initAutoIdPanel({
   function showPlaceholderResult() {
     if (resultEl) resultEl.textContent = '-';
   }
-  function runPulseId() {
+
+  function validateMandatoryInputs(forceShow = false) {
+    if (forceShow) showValidation = true;
     const callType = callTypeDropdown.items[callTypeDropdown.selectedIndex];
-    const high = parseFloat(inputs.high.value);
-    const low = parseFloat(inputs.low.value);
-    let valid = true;
-    if (callType === 'CF-FM' || callType === 'FM-CF-FM') {
-      valid = !isNaN(high);
-    } else if (callType === 'QCF') {
-      valid = !isNaN(low);
-    }
-    if (!valid) {
+    const requiredMap = {
+      'CF-FM': ['cfStart', 'cfEnd'],
+      'FM-CF-FM': ['cfStart', 'cfEnd'],
+      'FM': ['high', 'low'],
+      'FM-QCF': ['high', 'low', 'knee'],
+      'QCF': ['high', 'low'],
+    };
+    const required = requiredMap[callType] || [];
+    let allValid = true;
+    Object.entries(inputs).forEach(([key, el]) => {
+      if (!el) return;
+      if (required.includes(key)) {
+        const val = parseFloat(el.value);
+        const isValid = !isNaN(val);
+        if (showValidation) {
+          el.classList.toggle('invalid', !isValid);
+        }
+        if (!isValid) allValid = false;
+      } else if (showValidation) {
+        el.classList.remove('invalid');
+      }
+    });
+    return allValid;
+  }
+  function runPulseId() {
+    if (!validateMandatoryInputs(true)) {
       if (resultEl) resultEl.textContent = "-";
       return;
     }
+    const callType = callTypeDropdown.items[callTypeDropdown.selectedIndex];
+    const high = parseFloat(inputs.high.value);
+    const low = parseFloat(inputs.low.value);
     const res = autoIdHK({ callType, highFreq: high, lowFreq: low });
     if (resultEl) resultEl.innerHTML = formatSpeciesResult(res);
   }
 
 
+  function runSequenceId() {
+    if (!validateMandatoryInputs(true)) {
+      if (resultEl) resultEl.textContent = '-';
+      return;
+    }
+    showPlaceholderResult();
+  }
+
   pulseIdBtn?.addEventListener('click', runPulseId);
-  sequenceIdBtn?.addEventListener('click', showPlaceholderResult);
+  sequenceIdBtn?.addEventListener('click', runSequenceId);
 
   return {
     updateMarkers,


### PR DESCRIPTION
## Summary
- delay highlighting required fields until user attempts an ID
- keep validation state after first check and clear it when tabs are reset
- define validation flag before it is used
- clear invalid styling when reset buttons are used so hidden fields un-highlight
- fix knee frequency highlight persisting after first reset

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688054933b98832a8b1b7fb6286b02f9