### PR TITLE
Dispatch resize events for sidebar and tag mode

### DIFF
--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -21,15 +21,31 @@ export function initSidebar({ onFileSelected } = {}) {
 
   let isEditMode = false;
 
+  // Debounced helper to avoid flooding resize events when sidebar width changes.
+  const dispatchResize = (() => {
+    let timer;
+    return () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        // Triggering window resize recalculates spectrogram width and min zoom.
+        window.dispatchEvent(new Event('resize'));
+      }, 50);
+    };
+  })();
+
   toggleBtn.addEventListener('click', () => {
     sidebar.classList.toggle('collapsed');
     const isCollapsed = sidebar.classList.contains('collapsed');
     toggleBtn.title = isCollapsed ? 'Open File List' : 'Collapse File List';
+    // Inform spectrogram to recompute layout when sidebar width changes.
+    dispatchResize();
   });
 
   editBtn.addEventListener('click', () => {
     isEditMode = !isEditMode;
     sidebar.classList.toggle('edit-mode', isEditMode);
+    // Resize ensures spectrogram width updates when edit panel appears.
+    dispatchResize();
   });
 
   searchInput.addEventListener('input', () => {

--- a/modules/tagControl.js
+++ b/modules/tagControl.js
@@ -6,6 +6,17 @@ export function initTagControl() {
   const toggleTagModeBtn = document.getElementById('toggleTagModeBtn');
   const tagPanel = document.getElementById('tag-panel');
 
+  // Debounced resize dispatcher to sync spectrogram width with tag panel changes.
+  const dispatchResize = (() => {
+    let timer;
+    return () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        window.dispatchEvent(new Event('resize'));
+      }, 50);
+    };
+  })();
+
   const editTagsBtn = document.createElement('button');
   editTagsBtn.id = 'editTagsBtn';
   editTagsBtn.textContent = 'Edit Tags';
@@ -112,6 +123,8 @@ export function initTagControl() {
       document.getElementById('toggleEditBtn').click();
     }
     updateTagButtonStates();
+    // Notify layout changes when tag panel shifts spectrogram padding.
+    dispatchResize();
   }
 
   function exitTagMode() {
@@ -120,6 +133,8 @@ export function initTagControl() {
     if (!wasSidebarEdit && document.getElementById('sidebar').classList.contains('edit-mode')) {
       document.getElementById('toggleEditBtn').click();
     }
+    // Ensure spectrogram width recalculates after tag panel closes.
+    dispatchResize();
   }
 
   toggleTagModeBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure sidebar transitions trigger a debounced window resize event
- notify spectrogram width changes when tag mode is toggled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881022f5d3c832a893defb2ca216ab7