### PR TITLE
Handle time axis resize on sidebar toggle

### DIFF
--- a/main.js
+++ b/main.js
@@ -43,6 +43,7 @@ const hoverLabelElem = document.getElementById('hover-label');
 const zoomControlsElem = document.getElementById('zoom-controls');
 const playPauseBtn = document.getElementById('playPauseBtn');
 const stopBtn = document.getElementById('stopBtn');
+let containerWidth = container.clientWidth;
 let isDraggingProgress = false;
 let manualSeekTime = null;
 let duration = 0;
@@ -289,6 +290,19 @@ fileLoaderControl.loadFileAtIndex(index);
 hideDropOverlay();
 }
 });
+const sidebarElem = document.getElementById('sidebar');
+sidebarElem.addEventListener('sidebar-toggle', () => {
+  setTimeout(() => {
+    const prev = containerWidth;
+    zoomControl.applyZoom();
+    if (container.clientWidth !== prev) {
+      containerWidth = container.clientWidth;
+      renderAxes();
+      freqHoverControl?.refreshHover();
+      autoIdControl?.updateMarkers();
+    }
+  }, 310);
+});
 const tagControl = initTagControl();
 
 (async () => {
@@ -402,8 +416,9 @@ updateSpectrogramSettingsText();
 }
 
 const renderAxes = () => {
+  containerWidth = container.clientWidth;
   drawTimeAxis({
-    containerWidth: container.scrollWidth,
+    containerWidth,
     duration,
     zoomLevel: zoomControl.getZoomLevel(),
     axisElement: timeAxis,
@@ -427,7 +442,7 @@ hoverLineId: 'hover-line',
 hoverLineVId: 'hover-line-vertical',
 freqLabelId: 'hover-label',
 spectrogramHeight,
-spectrogramWidth: container.scrollWidth,
+    spectrogramWidth: containerWidth,
 maxFrequency: currentFreqMax,
 minFrequency: currentFreqMin,
 totalDuration: duration,
@@ -1046,9 +1061,9 @@ updateExpandBackBtn();
 });
 
 window.addEventListener('resize', () => {
-  const prevWidth = container.clientWidth;
   zoomControl.applyZoom();
-  if (container.clientWidth !== prevWidth) {
+  if (container.clientWidth !== containerWidth) {
+    containerWidth = container.clientWidth;
     renderAxes();
     freqHoverControl?.refreshHover();
     autoIdControl?.updateMarkers();

--- a/modules/sidebar.js
+++ b/modules/sidebar.js
@@ -25,6 +25,11 @@ export function initSidebar({ onFileSelected } = {}) {
     sidebar.classList.toggle('collapsed');
     const isCollapsed = sidebar.classList.contains('collapsed');
     toggleBtn.title = isCollapsed ? 'Open File List' : 'Collapse File List';
+    const evt = new CustomEvent('sidebar-toggle', {
+      bubbles: true,
+      detail: { collapsed: isCollapsed }
+    });
+    sidebar.dispatchEvent(evt);
   });
 
   editBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- dispatch custom `sidebar-toggle` event from sidebar
- track spectrogram container width in `main.js`
- redraw time axis when sidebar collapses or window resizes
- apply zoom when the sidebar width changes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688174f0db88832a8f75139fb61af5d7