### PR TITLE
Add mobile sidebar hiding

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,6 +69,28 @@ const canvasElem = document.getElementById("spectrogram-canvas");
 const offscreen = canvasElem.transferControlToOffscreen();
 const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
 specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+
+const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+if (isMobileDevice) {
+  showMessageBox({
+    title: 'Warning',
+    message: 'SonoRadar is optimized for desktop use. Android devices support viewer functionality only.'
+  });
+  [
+    'toggleSidebarBtn',
+    'toggleTagModeBtn',
+    'autoIdBtn',
+    'exportBtn',
+    'mapBtn',
+    'setting',
+    'spectrogram-settings',
+    'sidebar'
+  ]
+    .forEach(id => {
+      const el = document.getElementById(id);
+      if (el) el.classList.add('mobile-hidden');
+    });
+}
 function updateExpandBackBtn() {
   const count = expandHistory.length;
   expandBackBtn.style.display = count > 0 ? 'inline-flex' : 'none';

--- a/style.css
+++ b/style.css
@@ -15,6 +15,11 @@ html, body {
   user-select: none;
 }
 
+/* Hide elements on mobile devices */
+.mobile-hidden {
+  display: none !important;
+}
+
 /* === Viewer 結構 === */
 #viewer-wrapper {
   position: relative;


### PR DESCRIPTION
## Summary
- warn mobile users about limited functionality
- hide unsupported controls on mobile devices, including the sidebar

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_688186c3b66c832aafb9f9b0422761ea