### PR TITLE
Add window type dropdown

### DIFF
--- a/main.js
+++ b/main.js
@@ -53,6 +53,7 @@ let currentFreqMax = 128;
 let currentSampleRate = 256000;
 let selectedSampleRate = 'auto';
 let currentFftSize = 1024;
+let currentWindowType = 'hann';
 let currentOverlap = 'auto';
 let overlapWarningShown = false;
 let freqHoverControl = null;
@@ -692,6 +693,20 @@ const fftSizeDropdown = initDropdown('fftSizeInput', [
 ], { onChange: (item) => handleFftSize(item.value) });
 fftSizeDropdown.select(1);
 
+const windowTypeDropdown = initDropdown('windowTypeInput', [
+  { label: 'bartlett', value: 'bartlett' },
+  { label: 'bartlettHann', value: 'bartlettHann' },
+  { label: 'blackman', value: 'blackman' },
+  { label: 'cosine', value: 'cosine' },
+  { label: 'gauss', value: 'gauss' },
+  { label: 'hamming', value: 'hamming' },
+  { label: 'hann', value: 'hann' },
+  { label: 'lanczoz', value: 'lanczoz' },
+  { label: 'rectangular', value: 'rectangular' },
+  { label: 'triangular', value: 'triangular' },
+], { onChange: (item) => handleWindowType(item.value) });
+windowTypeDropdown.select(6);
+
 const overlapInput = document.getElementById('overlapInput');
 overlapInput.value = '';
 overlapInput.addEventListener('change', () => {
@@ -732,7 +747,7 @@ function updateSpectrogramSettingsText() {
   const sampleRate = currentSampleRate;
   const fftSize = currentFftSize;
   const overlap = getOverlapPercent();
-  const windowType = 'Hanning';
+  const windowType = currentWindowType.charAt(0).toUpperCase() + currentWindowType.slice(1);
 
   const overlapText = overlap !== null ? `${overlap}%` : 'Auto';
   if (textElem) {
@@ -785,25 +800,49 @@ document.getElementById('fileInput').click();
 });
 
 function handleFftSize(size) {
-currentFftSize = size;
-const colorMap = getCurrentColorMap();
-freqHoverControl?.hideHover();
-replacePlugin(
-colorMap,
-spectrogramHeight,
-currentFreqMin,
-currentFreqMax,
-getOverlapPercent(),
-() => {
-duration = getWavesurfer().getDuration();
-zoomControl.applyZoom();
-  renderAxes();
-  freqHoverControl?.refreshHover();
-  autoIdControl?.updateMarkers();
-},
-currentFftSize
-);
-updateSpectrogramSettingsText();
+  currentFftSize = size;
+  const colorMap = getCurrentColorMap();
+  freqHoverControl?.hideHover();
+  replacePlugin(
+    colorMap,
+    spectrogramHeight,
+    currentFreqMin,
+    currentFreqMax,
+    getOverlapPercent(),
+    () => {
+      duration = getWavesurfer().getDuration();
+      zoomControl.applyZoom();
+      renderAxes();
+      freqHoverControl?.refreshHover();
+      autoIdControl?.updateMarkers();
+    },
+    currentFftSize,
+    currentWindowType
+  );
+  updateSpectrogramSettingsText();
+}
+
+function handleWindowType(type) {
+  currentWindowType = type;
+  const colorMap = getCurrentColorMap();
+  freqHoverControl?.hideHover();
+  replacePlugin(
+    colorMap,
+    spectrogramHeight,
+    currentFreqMin,
+    currentFreqMax,
+    getOverlapPercent(),
+    () => {
+      duration = getWavesurfer().getDuration();
+      zoomControl.applyZoom();
+      renderAxes();
+      freqHoverControl?.refreshHover();
+      autoIdControl?.updateMarkers();
+    },
+    currentFftSize,
+    currentWindowType
+  );
+  updateSpectrogramSettingsText();
 }
 
 function handleOverlapChange() {

--- a/modules/wsManager.js
+++ b/modules/wsManager.js
@@ -7,6 +7,7 @@ let ws = null;
 let plugin = null;
 let currentColorMap = null;
 let currentFftSize = 1024;
+let currentWindowType = 'hann';
 
 export function initWavesurfer({
   container,
@@ -32,6 +33,7 @@ export function createSpectrogramPlugin({
   frequencyMax = 128,
   fftSamples = 1024,
   noverlap = null,
+  windowFunc = 'hann',
 }) {
   const baseOptions = {
     labels: false,
@@ -40,7 +42,7 @@ export function createSpectrogramPlugin({
     frequencyMin: frequencyMin * 1000,
     frequencyMax: frequencyMax * 1000,
     scale: 'linear',
-    windowFunc: 'hann',
+    windowFunc,
     colorMap,
   };
 
@@ -58,7 +60,8 @@ export function replacePlugin(
   frequencyMax = 128,
   overlapPercent = null,
   onRendered = null,  // ✅ 傳入 callback
-  fftSamples = currentFftSize
+  fftSamples = currentFftSize,
+  windowFunc = currentWindowType
 ) {
   if (!ws) throw new Error('Wavesurfer not initialized.');
   const container = document.getElementById("spectrogram-only");
@@ -71,6 +74,7 @@ export function replacePlugin(
   currentColorMap = colorMap;
 
   currentFftSize = fftSamples;
+  currentWindowType = windowFunc;
   const noverlap = overlapPercent !== null
     ? Math.floor(fftSamples * (overlapPercent / 100))
     : null;
@@ -82,6 +86,7 @@ export function replacePlugin(
     frequencyMax,
     fftSamples,
     noverlap,
+    windowFunc,
   });
 
   ws.registerPlugin(plugin);
@@ -110,6 +115,10 @@ export function getCurrentColorMap() {
 
 export function getCurrentFftSize() {
   return currentFftSize;
+}
+
+export function getCurrentWindowType() {
+  return currentWindowType;
 }
 
 export function initScrollSync({

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -98,6 +98,10 @@
         </label>
         <button id="applyFreqRangeBtn" title="Apply frequency range" class="toolbar-button"><i class="fa-solid fa-check"></i></button>
         <div class="toolbar-break"></div>
+        <label class="slider-label">Window Type
+          <button id="windowTypeInput" class="dropdown-button" title="Window Type">hann</button>
+        </label>
+        <div class="toolbar-break"></div>
         <i class="fa-solid fa-circle-half-stroke contrast-icon"></i>
         <input type="range" id="contrastSlider" min="0.5" max="2" step="0.05" value="1.25" title="Contrast">
         <span class="slider-value" id="contrastVal">1</span>


### PR DESCRIPTION
## Summary
- insert new **Window Type** dropdown in toolbar
- track `currentWindowType` in UI and manager
- allow `replacePlugin` to accept a window function
- update spectrogram settings display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688318451060832a98c774a6594f4da5