### PR TITLE
Fix window type dropdown width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1124,6 +1124,15 @@ input.tag-button.editing {
   border-top: 6px solid #333;
 }
 
+/* Set fixed width for Window Type dropdown */
+#windowTypeInput.dropdown-button {
+  width: 100px;
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .dropdown-menu {
   position: absolute;
   display: none;


### PR DESCRIPTION
## Summary
- style window type dropdown button so long text is truncated

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688330900e78832ab75527ba179b475c