### PR TITLE
Toggle route button icon when route shown

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -432,6 +432,9 @@ export function initMapPopup({
     polylines.forEach(l => l.remove());
     polylines = [];
     routeBtn?.classList.remove('active');
+    if (routeBtn) {
+      routeBtn.innerHTML = '<i class="fa-solid fa-eye"></i>';
+    }
   }
 
   function clearKmlRoute() {
@@ -523,6 +526,9 @@ export function initMapPopup({
     } else {
       drawRoute();
       routeBtn?.classList.add('active');
+      if (routeBtn) {
+        routeBtn.innerHTML = '<i class="fa-solid fa-eye-slash"></i>';
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- update Map Popup 'Create Route' button to toggle icon between eye and eye-slash

## Testing
- `grep -n "fa-eye" -n modules/mapPopup.js`

------
https://chatgpt.com/codex/tasks/task_e_6885856f6b30832a942076a924ce145f