### PR TITLE
Disable map interactions on popup controls

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -19,6 +19,18 @@ export function initMapPopup({
   if (!btn || !popup || !mapDiv) return;
   mapDiv.style.cursor = 'default';
 
+  function stopMapInteractions(e) {
+    if (e.target.closest('button') ||
+        e.target.closest('a') ||
+        e.target.closest('.coord-scale-wrapper')) {
+      e.stopPropagation();
+    }
+  }
+  mapDiv.addEventListener('pointerdown', stopMapInteractions, true);
+  mapDiv.addEventListener('click', stopMapInteractions, true);
+  mapDiv.addEventListener('dblclick', stopMapInteractions, true);
+  mapDiv.addEventListener('contextmenu', stopMapInteractions, true);
+
   const edgeThreshold = 5;
 
   function getEdgeState(clientX, clientY) {


### PR DESCRIPTION
## Summary
- prevent map drag, zoom and context actions when interacting with popup controls

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885f79a46f0832aaa2c75caf64c41c3