### PR TITLE
Fix hover lines while loading WAV

### DIFF
--- a/main.js
+++ b/main.js
@@ -261,8 +261,7 @@ freqHoverControl?.setPersistentLinesEnabled(false);
 function hideDropOverlay() {
 overlay.style.display = 'none';
 overlay.style.pointerEvents = 'none';
-hoverLineElem.style.display = 'block';
-  hoverLineVElem.style.display = 'block';
+  freqHoverControl?.hideHover();
   freqHoverControl?.setPersistentLinesEnabled(true);
   freqHoverControl?.refreshHover();
   autoIdControl?.updateMarkers();


### PR DESCRIPTION
## Summary
- keep hover lines hidden when dropping overlay is hidden

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887055c9004832aaae93d38d22d8862