### PR TITLE
Hide map controls on minimized popup

### DIFF
--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -87,6 +87,11 @@ export function initMapPopup({
   let copyMsgTimer = null;
   let scaleControl = null;
   let isMapDragging = false;
+  let layersControlContainer = null;
+  let zoomControlContainer = null;
+  let routeToggleContainer = null;
+  let exportControlContainer = null;
+  let textToggleContainer = null;
   const kmlInput = document.createElement('input');
   kmlInput.type = 'file';
   kmlInput.accept = '.kml';
@@ -170,6 +175,7 @@ export function initMapPopup({
 
   function createMap(lat, lon) {
     map = L.map(mapDiv).setView([lat, lon], 13);
+    zoomControlContainer = map.zoomControl.getContainer();
     map.on('dragstart', () => { isMapDragging = true; updateCursor(); });
     map.on('dragend', () => { isMapDragging = false; updateCursor(); });
     updateCursor();
@@ -280,6 +286,7 @@ export function initMapPopup({
     };
 
     layersControl = L.control.layers(baseLayers, null, { position: 'topright' }).addTo(map);
+    layersControlContainer = layersControl.getContainer();
 
     fetch("https://raw.githubusercontent.com/PanTong55/spectrogram/main/hkgrid.geojson")
       .then((r) => r.json())
@@ -376,7 +383,9 @@ export function initMapPopup({
         return container;
       }
     });
-    map.addControl(new RouteToggleControl());
+    const routeControl = new RouteToggleControl();
+    map.addControl(routeControl);
+    routeToggleContainer = routeControl.getContainer();
 
     const TextToggleControl = L.Control.extend({
       options: { position: 'topleft' },
@@ -397,7 +406,9 @@ export function initMapPopup({
         return container;
       }
     });
-    map.addControl(new TextToggleControl());
+    const textControl = new TextToggleControl();
+    map.addControl(textControl);
+    textToggleContainer = textControl.getContainer();
 
     const ExportControl = L.Control.extend({
       options: { position: 'topleft' },
@@ -418,7 +429,9 @@ export function initMapPopup({
         return container;
       }
     });
-    map.addControl(new ExportControl());
+    const exportControl = new ExportControl();
+    map.addControl(exportControl);
+    exportControlContainer = exportControl.getContainer();
 
     const DrawToggleControl = L.Control.extend({
       options: { position: 'topleft' },
@@ -439,7 +452,8 @@ export function initMapPopup({
         return container;
       }
     });
-    map.addControl(new DrawToggleControl());
+    const drawToggle = new DrawToggleControl();
+    map.addControl(drawToggle);
   }
 
   function refreshMarkers() {
@@ -907,6 +921,12 @@ export function initMapPopup({
       popup.style.width = '290px';
       popup.style.height = '360px';
       minBtn.innerHTML = '<i class="fa-solid fa-window-maximize"></i>';
+      if (layersControlContainer) layersControlContainer.style.display = 'none';
+      if (zoomControlContainer) zoomControlContainer.style.display = 'none';
+      if (routeToggleContainer) routeToggleContainer.style.display = 'none';
+      if (exportControlContainer) exportControlContainer.style.display = 'none';
+      if (coordScaleWrapper) coordScaleWrapper.style.display = 'none';
+      if (textToggleContainer) textToggleContainer.style.setProperty('margin-top', '10px', 'important');
       isMinimized = true;
     } else {
       popup.style.width = `${minPrevWidth}px`;
@@ -914,6 +934,12 @@ export function initMapPopup({
       popup.style.left = `${minPrevLeft}px`;
       popup.style.top = `${minPrevTop}px`;
       minBtn.innerHTML = '<i class="fa-solid fa-window-minimize"></i>';
+      if (layersControlContainer) layersControlContainer.style.display = '';
+      if (zoomControlContainer) zoomControlContainer.style.display = '';
+      if (routeToggleContainer) routeToggleContainer.style.display = '';
+      if (exportControlContainer) exportControlContainer.style.display = '';
+      if (coordScaleWrapper) coordScaleWrapper.style.display = '';
+      if (textToggleContainer) textToggleContainer.style.setProperty('margin-top', '1px', 'important');
       isMinimized = false;
     }
     map?.invalidateSize();


### PR DESCRIPTION
## Summary
- hide map controls when map popup minimized
- store text control container and adjust margin when minimized

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688757d64404832a95edbfcbf298b02a