### PR TITLE
Fix spectrogram hang when switching to short file

### DIFF
--- a/main.js
+++ b/main.js
@@ -67,9 +67,16 @@ const expandBackBtn = document.getElementById('expandBackBtn');
 const expandBackCount = document.getElementById('expandBackCount');
 let ignoreNextPause = false;
 const canvasElem = document.getElementById("spectrogram-canvas");
-const offscreen = canvasElem.transferControlToOffscreen();
-const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
-specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+let specWorker = null;
+
+function restartSpecWorker() {
+  if (specWorker) specWorker.terminate();
+  const offscreen = canvasElem.transferControlToOffscreen();
+  specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
+  specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+}
+
+restartSpecWorker();
 
 const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 if (isMobileDevice) {
@@ -276,8 +283,8 @@ fileLoaderControl = initFileLoader({
 fileInputId: 'fileInput',
 wavesurfer: getWavesurfer(),
 spectrogramHeight,
-colorMap: [],
-onPluginReplaced: () => {},
+  colorMap: [],
+  onPluginReplaced: resetSpectrogram,
 onFileLoaded: (file) => {
 hideDropOverlay();
 zoomControlsElem.style.display = 'flex';
@@ -605,9 +612,9 @@ duration = getWavesurfer().getDuration();
 initDragDropLoader({
 targetElementId: 'viewer-wrapper',
 wavesurfer: getWavesurfer(),
-spectrogramHeight,
-colorMap: [],
-onPluginReplaced: () => {},
+  spectrogramHeight,
+  colorMap: [],
+  onPluginReplaced: resetSpectrogram,
 onFileLoaded: (file) => {
 hideDropOverlay();
 zoomControlsElem.style.display = 'flex';
@@ -888,6 +895,27 @@ autoIdControl?.updateMarkers();
 updateSpectrogramSettingsText();
 }
 
+function resetSpectrogram() {
+  const colorMap = getCurrentColorMap();
+  freqHoverControl?.hideHover();
+  replacePlugin(
+    colorMap,
+    spectrogramHeight,
+    currentFreqMin,
+    currentFreqMax,
+    getOverlapPercent(),
+    () => {
+      duration = getWavesurfer().getDuration();
+      zoomControl.applyZoom();
+      renderAxes();
+      freqHoverControl?.refreshHover();
+      autoIdControl?.updateMarkers();
+    }
+  );
+  drawColorBar(colorMap);
+  updateSpectrogramSettingsText();
+}
+
 const clearAllBtn = document.getElementById('clearAllBtn');
 clearAllBtn.addEventListener('click', () => {
 clearFileList();
@@ -1107,6 +1135,7 @@ document.addEventListener("file-loaded", async () => {
   updateExpandBackBtn();
   autoIdControl?.reset();
   if (currentFile) {
+    restartSpecWorker();
     const arrayBuf = await currentFile.arrayBuffer();
     const ac = new (window.AudioContext || window.webkitAudioContext)();
     const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));


### PR DESCRIPTION
## Summary
- restart spectrogram worker on every file load
- add `resetSpectrogram` helper
- refresh spectrogram plugin when loading files via input or drag & drop

## Testing
- `node -e "require('./main.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68882cb1da08832a9a34dbfdc59b2a8f