### PR TITLE
Add hover and expand improvements

### DIFF
--- a/main.js
+++ b/main.js
@@ -482,14 +482,24 @@ getZoomLevel: () => zoomControl.getZoomLevel(),
 
 const wrapper = document.getElementById('viewer-wrapper');
 const zoomControl = initZoomControls(
-getWavesurfer(),
-container,
-getDuration,
-renderAxes,
-wrapper,
-() => { freqHoverControl?.hideHover(); },
-() => { freqHoverControl?.refreshHover(); autoIdControl?.updateMarkers(); },
-() => selectionExpandMode
+  getWavesurfer(),
+  container,
+  getDuration,
+  renderAxes,
+  wrapper,
+  () => { freqHoverControl?.hideHover(); },
+  () => { freqHoverControl?.refreshHover(); autoIdControl?.updateMarkers(); },
+  () => selectionExpandMode,
+  () => {
+    const sel = freqHoverControl?.getHoveredSelection?.();
+    if (sel) {
+      viewer.dispatchEvent(new CustomEvent('expand-selection', {
+        detail: { startTime: sel.data.startTime, endTime: sel.data.endTime }
+      }));
+      return true;
+    }
+    return false;
+  }
 );
 
 function updateProgressLine(time) {

--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -22,6 +22,7 @@ export function initFrequencyHover({
   const container = document.getElementById('spectrogram-only');
   const persistentLines = [];
   const selections = [];
+  let hoveredSelection = null;
   let persistentLinesEnabled = true;
   let disablePersistentLinesForScrollbar = false;
   const defaultScrollbarThickness = 20;
@@ -253,6 +254,8 @@ export function initFrequencyHover({
     }
 
     enableResize(selObj);
+    selObj.rect.addEventListener('mouseenter', () => { hoveredSelection = selObj; });
+    selObj.rect.addEventListener('mouseleave', () => { if (hoveredSelection === selObj) hoveredSelection = null; });
   }
 
   function removeSelection(sel) {
@@ -261,6 +264,7 @@ export function initFrequencyHover({
       viewer.removeChild(selections[index].rect);
       if (selections[index].tooltip) viewer.removeChild(selections[index].tooltip);
       selections.splice(index, 1);
+      if (hoveredSelection === sel) hoveredSelection = null;
     }
   }
 
@@ -614,6 +618,7 @@ export function initFrequencyHover({
         updateHoverDisplay({ clientX: lastClientX, clientY: lastClientY });
       }
     },
-    setPersistentLinesEnabled: (val) => { persistentLinesEnabled = val; }
+    setPersistentLinesEnabled: (val) => { persistentLinesEnabled = val; },
+    getHoveredSelection: () => hoveredSelection
   };
 }

--- a/modules/zoomControl.js
+++ b/modules/zoomControl.js
@@ -2,7 +2,8 @@
 
 export function initZoomControls(ws, container, duration, applyZoomCallback,
                                 wrapperElement, onBeforeZoom = null,
-                                onAfterZoom = null, isSelectionExpandMode = () => false) {
+                                onAfterZoom = null, isSelectionExpandMode = () => false,
+                                onCtrlArrowUp = null) {
   const zoomInBtn = document.getElementById('zoom-in');
   const zoomOutBtn = document.getElementById('zoom-out');
   const expandBtn = document.getElementById('expand-btn');
@@ -89,6 +90,14 @@ export function initZoomControls(ws, container, duration, applyZoomCallback,
 
   document.addEventListener('keydown', (e) => {
     if (!e.ctrlKey) return;  // 只監聽 Ctrl + *
+
+    if (e.key === 'ArrowUp' && typeof onCtrlArrowUp === 'function') {
+      const handled = onCtrlArrowUp();
+      if (handled) {
+        e.preventDefault();
+        return;
+      }
+    }
 
     switch (e.key) {
       case 'ArrowUp':

--- a/style.css
+++ b/style.css
@@ -1300,6 +1300,11 @@ input.tag-button.editing {
   border: 1px solid black;
   background-color: rgba(0,0,0,0.05);
   z-index: 20;
+  transition: background-color 0.2s;
+}
+
+.selection-rect:hover {
+  background-color: rgba(0,0,0,0.1);
 }
 
 .persistent-line {


### PR DESCRIPTION
## Summary
- add smooth hover effect for selection areas
- track hovered selection in frequencyHover
- allow ctrl+ArrowUp to expand hovered selection
- connect new callback in zoom control

## Testing
- `node --check main.js`
- `node --check modules/frequencyHover.js`
- `node --check modules/zoomControl.js`


------
https://chatgpt.com/codex/tasks/task_e_688ad54291cc832aa323d9f7313fd9e7