### PR TITLE
Improve selection area interactions

### DIFF
--- a/modules/frequencyHover.js
+++ b/modules/frequencyHover.js
@@ -600,6 +600,26 @@ export function initFrequencyHover({
     window.addEventListener('mouseup', () => { isDragging = false; });
   }
 
+  document.addEventListener('keydown', (e) => {
+    if (!(e.ctrlKey && e.key === 'ArrowUp')) return;
+    if (!isCursorInside || isDrawing || isResizing) return;
+    if (lastClientX === null || lastClientY === null) return;
+
+    for (let i = selections.length - 1; i >= 0; i--) {
+      const sel = selections[i];
+      const rect = sel.rect.getBoundingClientRect();
+      if (lastClientX >= rect.left && lastClientX <= rect.right &&
+          lastClientY >= rect.top && lastClientY <= rect.bottom) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        viewer.dispatchEvent(new CustomEvent('expand-selection', {
+          detail: { startTime: sel.data.startTime, endTime: sel.data.endTime }
+        }));
+        break;
+      }
+    }
+  });
+
   return {
     updateSelections,
     clearSelections,

--- a/style.css
+++ b/style.css
@@ -1299,7 +1299,12 @@ input.tag-button.editing {
   position: absolute;
   border: 1px solid black;
   background-color: rgba(0,0,0,0.05);
+  transition: background-color 0.2s ease;
   z-index: 20;
+}
+
+.selection-rect:hover {
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 .persistent-line {


### PR DESCRIPTION
## Summary
- soften hover transitions for selection rectangles
- highlight selection rectangle on cursor hover
- allow expanding a hovered selection with **Ctrl+ArrowUp**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad54291cc832aa323d9f7313fd9e7