### PR TITLE
Update selection button group visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -397,6 +397,9 @@ input[type="file"]:hover {
   border-radius: 12px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
   z-index: 25;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 
 .selection-btn-group i {
@@ -414,6 +417,11 @@ input[type="file"]:hover {
 
 .selection-btn-group i:hover {
   background: rgba(255, 255, 255, 0.9);
+}
+
+.selection-rect:hover .selection-btn-group {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* === Selection Duration Label === */


### PR DESCRIPTION
## Summary
- show selection button group only when hovering a selection

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688c5a25df14832aaa5b6a6effb9533b