### PR TITLE
Disable ID buttons when warnings present

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -160,6 +160,7 @@ export function initAutoIdPanel({
     const showOrder = !isNaN(high) && !isNaN(low) && low > high;
     const showKneeOrder = !isNaN(knee) && !isNaN(low) && knee < low;
     const showTimeOrder = startT != null && endT != null && endT < startT;
+    const hasWarnings = showBandwidth || showOrder || showKneeOrder || showTimeOrder;
     if (inputs.high) inputs.high.classList.toggle('warning', showBandwidth || showOrder);
     if (inputs.low) inputs.low.classList.toggle('warning', showBandwidth || showOrder || showKneeOrder);
     if (inputs.knee) inputs.knee.classList.toggle('warning', showKneeOrder);
@@ -169,6 +170,8 @@ export function initAutoIdPanel({
     if (freqOrderWarning) freqOrderWarning.style.display = showOrder ? 'flex' : 'none';
     if (kneeOrderWarning) kneeOrderWarning.style.display = showKneeOrder ? 'flex' : 'none';
     if (timeOrderWarning) timeOrderWarning.style.display = showTimeOrder ? 'flex' : 'none';
+    if (pulseIdBtn) pulseIdBtn.disabled = hasWarnings;
+    if (sequenceIdBtn) sequenceIdBtn.disabled = hasWarnings;
   }
 
   const markerColors = {

--- a/style.css
+++ b/style.css
@@ -745,6 +745,13 @@ input[type="file"]:hover {
   background-color: #ffd700;
 }
 
+.autoid-action-btn:disabled,
+.autoid-action-btn:disabled:hover {
+  background-color: #e0e0e0;
+  color: #777;
+  cursor: not-allowed;
+}
+
 .autoid-result-label {
   font-size: 14px;
 }


### PR DESCRIPTION
## Summary
- Disable Pulse ID and Sequence ID buttons whenever any auto ID warnings are shown
- Add CSS styling for disabled auto ID action buttons

## Testing
- `node --check modules/autoIdPanel.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e25c9b268832aacf099da2b9f4828