### PR TITLE
Handle unmatched species with harmonic support for HK auto ID

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -668,7 +668,7 @@ export function initAutoIdPanel({
         const genus = name.replace(' sp.', '');
         return `<i>${genus}</i> sp.`;
       }
-      if (name === 'TBC' || name === '-') return name;
+      if (name === 'TBC' || name === '-' || name === 'No species matched') return name;
       return `<i>${name}</i>`;
     }).join(' / ');
   }
@@ -744,9 +744,14 @@ export function initAutoIdPanel({
     const kneeLowBandwidth = !isNaN(knee) && !isNaN(low) ? knee - low : null;
     const heelLowBandwidth = !isNaN(heel) && !isNaN(low) ? heel - low : null;
     const kneeHeelBandwidth = !isNaN(knee) && !isNaN(heel) ? knee - heel : null;
+    const harmonic = parseInt(
+      harmonicDropdown.items[harmonicDropdown.selectedIndex],
+      10
+    );
 
     const res = autoIdHK({
       callType,
+      harmonic,
       highestFreq: high,
       lowestFreq: low,
       kneeFreq: knee,
@@ -766,14 +771,8 @@ export function initAutoIdPanel({
     updateResultDisplay();
   }
 
-
   function runSequenceId() {
-    if (!validateMandatoryInputs(true)) {
-      if (resultEl) resultEl.textContent = '-';
-      return;
-    }
-    tabData[currentTab].result = null;
-    showPlaceholderResult();
+    runPulseId();
   }
 
   pulseIdBtn?.addEventListener('click', runPulseId);

--- a/modules/autoid_HK.js
+++ b/modules/autoid_HK.js
@@ -5,68 +5,80 @@ const speciesRules = [
     name: 'Hipposideros gentilis',
     callType: 'CF-FM',
     cfStart: [120, 130],
-    duration: [5, 10]
+    duration: [5, 10],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Hipposideros armiger',
     callType: 'CF-FM',
     cfStart: [60, 70],
-    duration: [10, 18]
+    duration: [10, 18],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Rhinolophus pusillus',
     callType: 'FM-CF-FM',
     cfStart: [100, 110],
-    duration: [30, 70]
+    duration: [30, 70],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Rhinolophus sinicus',
     callType: 'FM-CF-FM',
     cfStart: [75, 87],
-    duration: [30, 70]
+    duration: [30, 70],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Rhinolophus affinis',
     callType: 'FM-CF-FM',
     cfStart: [68, 75],
-    duration: [30, 80]
+    duration: [30, 80],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Pipistrellus tenuis',
     callType: 'QCF',
     lowestFreq: [39, 42],
     bandwidth: [1, 5],
-    duration: [5, 10]
+    duration: [5, 10],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Pipistrellus abramus',
     callType: 'QCF',
-    lowestFreq: [44, 46]
+    lowestFreq: [44, 46],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Hypsugo pulveratus',
     callType: 'QCF',
-    lowestFreq: [32, 36]
+    lowestFreq: [32, 36],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Pipistrellus ceylonicus',
     callType: 'QCF',
-    lowestFreq: [30, 32]
+    lowestFreq: [30, 32],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Nyctalus plancyi',
     callType: 'QCF',
-    lowestFreq: [17.5, 21]
+    lowestFreq: [17.5, 21],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Mops plicatus',
     callType: 'QCF',
-    lowestFreq: [[17.5, 21], [13, 16.5]]
+    lowestFreq: [[17.5, 21], [13, 16.5]],
+    harmonic: [0, 1, 2, 3]
   },
   {
     name: 'Taphozous melanopogon',
     callType: 'QCF',
-    lowestFreq: [24.5, 26]
+    lowestFreq: [24.5, 26],
+    harmonic: [0, 1, 2, 3]
   }
 ];
 
@@ -81,6 +93,7 @@ export function autoIdHK(data = {}) {
   if (data.callType === 'FM' || data.callType === 'FM-QCF') return 'TBC';
   const matches = speciesRules.filter(rule => {
     if (rule.callType && rule.callType !== data.callType) return false;
+    if (rule.harmonic && !rule.harmonic.includes(data.harmonic)) return false;
     const fields = [
       'highestFreq', 'lowestFreq', 'kneeFreq', 'heelFreq',
       'startFreq', 'endFreq', 'cfStart', 'cfEnd', 'duration',
@@ -89,7 +102,5 @@ export function autoIdHK(data = {}) {
     ];
     return fields.every(f => !rule[f] || inRange(data[f], rule[f]));
   }).map(r => r.name);
-  if (matches.length) return matches.join(' / ');
-  const fallback = { 'CF-FM': 'Hipposideros sp.', 'FM-CF-FM': 'Rhinolophus sp.' };
-  return fallback[data.callType] || '-';
+  return matches.length ? matches.join(' / ') : 'No species matched';
 }


### PR DESCRIPTION
## Summary
- show "No species matched" when auto-ID finds no match
- add harmonic field to species rules and pass from the UI
- reuse Pulse ID logic for Sequence ID button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e298ccd90832a8f6a3041e0a8474b