### PR TITLE
Remove TBC rule from Hong Kong auto-ID

### DIFF
--- a/modules/autoid_HK.js
+++ b/modules/autoid_HK.js
@@ -90,7 +90,6 @@ function inRange(val, range) {
 }
 
 export function autoIdHK(data = {}) {
-  if (data.callType === 'FM' || data.callType === 'FM-QCF') return 'TBC';
   const matches = speciesRules.filter(rule => {
     if (rule.callType && rule.callType !== data.callType) return false;
     if (rule.harmonic && !rule.harmonic.includes(data.harmonic)) return false;


### PR DESCRIPTION
## Summary
- drop special-case that returned `TBC` for FM or FM-QCF call types in HK auto ID module

## Testing
- `node -e "require('./modules/autoid_HK.js'); console.log('module loaded')"`


------
https://chatgpt.com/codex/tasks/task_e_688e2d6ce9ec832a919943065f2edf49