### PR TITLE
Show auto-id marker tooltips immediately

### DIFF
--- a/sonoradar.html
+++ b/sonoradar.html
@@ -162,7 +162,7 @@
           <div class="autoid-field">
             <input id="cfStartFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire CF Start Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-cfstart" data-key="cfStart" title="Reset CF start freq.">
+            <button class="autoid-marker marker-cfstart" data-key="cfStart" data-title="Reset CF start freq." aria-label="Reset CF start freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -172,7 +172,7 @@
           <div class="autoid-field">
             <input id="cfEndFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire CF End Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-cfend" data-key="cfEnd" title="Reset CF end freq.">
+            <button class="autoid-marker marker-cfend" data-key="cfEnd" data-title="Reset CF end freq." aria-label="Reset CF end freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -182,7 +182,7 @@
           <div class="autoid-field">
             <input id="startFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Start Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-start" data-key="start" title="Reset Start freq.">
+            <button class="autoid-marker marker-start" data-key="start" data-title="Reset Start freq." aria-label="Reset Start freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -192,7 +192,7 @@
           <div class="autoid-field">
             <input id="endFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire End Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-end" data-key="end" title="Reset End freq.">
+            <button class="autoid-marker marker-end" data-key="end" data-title="Reset End freq." aria-label="Reset End freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -202,7 +202,7 @@
           <div class="autoid-field">
             <input id="highFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Highest Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-high" data-key="high" title="Reset High freq.">
+            <button class="autoid-marker marker-high" data-key="high" data-title="Reset High freq." aria-label="Reset High freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -212,7 +212,7 @@
           <div class="autoid-field">
             <input id="lowFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Lowest Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-low" data-key="low" title="Reset Low freq.">
+            <button class="autoid-marker marker-low" data-key="low" data-title="Reset Low freq." aria-label="Reset Low freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -222,7 +222,7 @@
           <div class="autoid-field">
             <input id="kneeFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Knee Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-knee" data-key="knee" title="Reset Knee freq.">
+            <button class="autoid-marker marker-knee" data-key="knee" data-title="Reset Knee freq." aria-label="Reset Knee freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>
@@ -232,7 +232,7 @@
           <div class="autoid-field">
             <input id="heelFreqInput" class="autoid-input" type="text" readonly title="Click on spectrogram to acquire Heel Frequency">
             <span class="autoid-unit">kHz</span>
-            <button class="autoid-marker marker-heel" data-key="heel" title="Reset Heel freq.">
+            <button class="autoid-marker marker-heel" data-key="heel" data-title="Reset Heel freq." aria-label="Reset Heel freq.">
               <i class="fa-solid fa-xmark"></i>
             </button>
           </div>

--- a/style.css
+++ b/style.css
@@ -762,6 +762,7 @@ input[type="file"]:hover {
   border: none;
   cursor: pointer;
   padding: 0;
+  position: relative;
 }
 #auto-id-panel .autoid-marker:hover {
   color: #000;
@@ -769,6 +770,22 @@ input[type="file"]:hover {
 #auto-id-panel .autoid-marker:disabled {
   color: #aaa;
   cursor: not-allowed;
+}
+
+.autoid-marker[data-title]:hover::after {
+  content: attr(data-title);
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 4px);
+  background: #333;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+  font-size: 12px;
 }
 
 .freq-marker {


### PR DESCRIPTION
## Summary
- Replace default HTML title attributes on auto-ID reset buttons with `data-title` and `aria-label`
- Add CSS pseudo-element to display tooltip text instantly on hover

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e349dfce8832a8299e6b73684e507