### PR TITLE
Show spectrogram marker tooltips immediately

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -185,6 +185,17 @@ export function initAutoIdPanel({
     cfEnd: '#1abc9c'
   };
 
+  const markerTitles = {
+    start: 'Start freq.',
+    end: 'End freq.',
+    high: 'High freq.',
+    low: 'Low freq.',
+    knee: 'Knee freq.',
+    heel: 'Heel freq.',
+    cfStart: 'CF start',
+    cfEnd: 'CF end'
+  };
+
   let markers = tabData[currentTab].markers;
 
   let active = null;
@@ -383,7 +394,9 @@ export function initAutoIdPanel({
     el.style.color = markerColors[key];
     el.dataset.key = key;
     el.dataset.tab = tabIdx;
-    el.title = `${key.charAt(0).toUpperCase() + key.slice(1)} freq. marker`;
+    const title = markerTitles[key] || key;
+    el.dataset.title = title;
+    el.setAttribute('aria-label', title);
     el.addEventListener('mouseenter', hideHover);
     el.addEventListener('mouseleave', refreshHover);
     el.addEventListener('mousedown', (ev) => {

--- a/style.css
+++ b/style.css
@@ -778,6 +778,21 @@ input[type="file"]:hover {
   cursor: move !important;
   z-index: 30;
 }
+.freq-marker[data-title]:hover::after {
+  content: attr(data-title);
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translate(-50%, -4px);
+  background: #333;
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+  font-size: 12px;
+}
 body.markers-disabled .freq-marker {
   pointer-events: none !important;
   cursor: default !important;


### PR DESCRIPTION
## Summary
- Restore Auto-ID panel reset buttons to use standard `title` attributes
- Show spectrogram frequency marker titles immediately via `data-title`/`aria-label` and style them as "Start freq.", "End freq.", "High freq.", "Low freq.", "Knee freq.", "Heel freq.", "CF start" and "CF end"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e349dfce8832a8299e6b73684e507