### PR TITLE
fix: elevate titled frequency markers

### DIFF
--- a/style.css
+++ b/style.css
@@ -778,6 +778,9 @@ input[type="file"]:hover {
   cursor: move !important;
   z-index: 30;
 }
+.freq-marker[data-title] {
+  z-index: 31;
+}
 .freq-marker[data-title]:hover::after {
   content: attr(data-title);
   position: absolute;


### PR DESCRIPTION
## Summary
- ensure `.freq-marker` elements with `data-title` render above other markers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e4076b998832aa4ceaaf24346261f