### PR TITLE
Deduplicate species matches in auto ID

### DIFF
--- a/modules/autoid_HK.js
+++ b/modules/autoid_HK.js
@@ -90,7 +90,7 @@ function inRange(val, range) {
 }
 
 export function autoIdHK(data = {}) {
-  const matches = speciesRules.filter(rule => {
+  const matches = [...new Set(speciesRules.filter(rule => {
     if (rule.callType && rule.callType !== data.callType) return false;
     if (rule.harmonic && !rule.harmonic.includes(data.harmonic)) return false;
     const fields = [
@@ -100,6 +100,6 @@ export function autoIdHK(data = {}) {
       'heelLowBandwidth', 'kneeHeelBandwidth'
     ];
     return fields.every(f => !rule[f] || inRange(data[f], rule[f]));
-  }).map(r => r.name);
+  }).map(r => r.name))];
   return matches.length ? matches.join(' / ') : 'No species matched';
 }


### PR DESCRIPTION
## Summary
- remove duplicate species names when computing Hong Kong auto identification matches by wrapping results in a Set

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check modules/autoid_HK.js`


------
https://chatgpt.com/codex/tasks/task_e_688e45659504832a82ab97f6cb936852