### PR TITLE
Add rendering timeout for spectrogram

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,6 +71,14 @@ const canvasElem = document.getElementById("spectrogram-canvas");
 const offscreen = canvasElem.transferControlToOffscreen();
 const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
 specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+specWorker.onmessage = (e) => {
+  if (e.data?.type === 'timeout') {
+    showMessageBox({
+      title: 'Rendering Timeout',
+      message: 'The spectrogram rendering took too long. Please adjust the settings or shorten the recording length.'
+    });
+  }
+};
 
 const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 if (isMobileDevice) {

--- a/spectrogramWorker.js
+++ b/spectrogramWorker.js
@@ -22,7 +22,12 @@ function renderSpectrogram(signal, sr, fftSize, overlapPct) {
   const window = hannWindow(fftSize);
   const real = new Float32Array(fftSize);
   const imag = new Float32Array(fftSize);
+  const startTime = performance.now();
   for (let x = 0, i = 0; i + fftSize <= signal.length; i += hop, x++) {
+    if (performance.now() - startTime > 10000) {
+      self.postMessage({ type: 'timeout' });
+      return;
+    }
     for (let j = 0; j < fftSize; j++) {
       real[j] = signal[i + j] * window[j];
       imag[j] = 0;


### PR DESCRIPTION
## Summary
- abort spectrogram rendering if it runs longer than 10 seconds
- notify users with a "Rendering Timeout" message box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ee8592018832aae694a5a627d253f