### PR TITLE
Add rendering timeout for spectrogram

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,8 +69,17 @@ const expandBackCount = document.getElementById('expandBackCount');
 let ignoreNextPause = false;
 const canvasElem = document.getElementById("spectrogram-canvas");
 const offscreen = canvasElem.transferControlToOffscreen();
+const cancelBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT);
+const cancelFlag = new Int32Array(cancelBuffer);
 const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
-specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+specWorker.postMessage({ type: "init", canvas: offscreen, cancelBuffer }, [offscreen]);
+let renderTimeoutId = null;
+specWorker.onmessage = (e) => {
+  if (e.data?.type === 'rendered' && renderTimeoutId !== null) {
+    clearTimeout(renderTimeoutId);
+    renderTimeoutId = null;
+  }
+};
 
 const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 if (isMobileDevice) {
@@ -1143,6 +1152,18 @@ document.addEventListener("file-loaded", async () => {
     const arrayBuf = await currentFile.arrayBuffer();
     const ac = new (window.AudioContext || window.webkitAudioContext)();
     const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));
+    if (renderTimeoutId !== null) {
+      clearTimeout(renderTimeoutId);
+    }
+    Atomics.store(cancelFlag, 0, 0);
+    renderTimeoutId = setTimeout(() => {
+      Atomics.store(cancelFlag, 0, 1);
+      showMessageBox({
+        title: 'Rendering Timeout',
+        message: 'The spectrogram rendering took too long. Please adjust the settings or shorten the recording length.'
+      });
+      renderTimeoutId = null;
+    }, 10000);
     specWorker.postMessage({ type: "render", buffer: audioBuf.getChannelData(0), sampleRate: audioBuf.sampleRate, fftSize: currentFftSize, overlap: getOverlapPercent() }, [audioBuf.getChannelData(0).buffer]);
   }
 });

--- a/spectrogramWorker.js
+++ b/spectrogramWorker.js
@@ -1,4 +1,5 @@
 let canvas, ctx, sampleRate = 44100;
+let cancelFlag;
 
 self.onmessage = (e) => {
   const { type } = e.data;
@@ -6,6 +7,9 @@ self.onmessage = (e) => {
     canvas = e.data.canvas;
     sampleRate = e.data.sampleRate || sampleRate;
     ctx = canvas.getContext('2d');
+    if (e.data.cancelBuffer) {
+      cancelFlag = new Int32Array(e.data.cancelBuffer);
+    }
   } else if (type === 'render') {
     if (!ctx) return;
     renderSpectrogram(e.data.buffer, e.data.sampleRate || sampleRate, e.data.fftSize || 1024, e.data.overlap || 0);
@@ -23,6 +27,9 @@ function renderSpectrogram(signal, sr, fftSize, overlapPct) {
   const real = new Float32Array(fftSize);
   const imag = new Float32Array(fftSize);
   for (let x = 0, i = 0; i + fftSize <= signal.length; i += hop, x++) {
+    if (cancelFlag && Atomics.load(cancelFlag, 0) === 1) {
+      return;
+    }
     for (let j = 0; j < fftSize; j++) {
       real[j] = signal[i + j] * window[j];
       imag[j] = 0;


### PR DESCRIPTION
## Summary
- abort spectrogram rendering if it runs longer than 10 seconds
- notify users with a "Rendering Timeout" message box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ee8592018832aae694a5a627d253f