### PR TITLE
Add rendering timeout for spectrogram

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,8 +69,32 @@ const expandBackCount = document.getElementById('expandBackCount');
 let ignoreNextPause = false;
 const canvasElem = document.getElementById("spectrogram-canvas");
 const offscreen = canvasElem.transferControlToOffscreen();
-const specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
-specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+let specWorker;
+let renderTimerId = null;
+
+function initSpecWorker() {
+  specWorker = new Worker("./spectrogramWorker.js", { type: "module" });
+  specWorker.postMessage({ type: "init", canvas: offscreen }, [offscreen]);
+  specWorker.onmessage = (e) => {
+    if (e.data?.type === 'timeout') {
+      if (renderTimerId !== null) {
+        clearTimeout(renderTimerId);
+        renderTimerId = null;
+        showMessageBox({
+          title: 'Rendering Timeout',
+          message: 'The spectrogram rendering took too long. Please adjust the settings or shorten the recording length.'
+        });
+      }
+    } else if (e.data?.type === 'rendered') {
+      if (renderTimerId !== null) {
+        clearTimeout(renderTimerId);
+        renderTimerId = null;
+      }
+    }
+  };
+}
+
+initSpecWorker();
 
 const isMobileDevice = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 if (isMobileDevice) {
@@ -1143,6 +1167,18 @@ document.addEventListener("file-loaded", async () => {
     const arrayBuf = await currentFile.arrayBuffer();
     const ac = new (window.AudioContext || window.webkitAudioContext)();
     const audioBuf = await ac.decodeAudioData(arrayBuf.slice(0));
+    if (renderTimerId !== null) {
+      clearTimeout(renderTimerId);
+      renderTimerId = null;
+    }
+    renderTimerId = setTimeout(() => {
+      renderTimerId = null;
+      specWorker.postMessage({ type: 'abort' });
+      showMessageBox({
+        title: 'Rendering Timeout',
+        message: 'The spectrogram rendering took too long. Please adjust the settings or shorten the recording length.'
+      });
+    }, 10000);
     specWorker.postMessage({ type: "render", buffer: audioBuf.getChannelData(0), sampleRate: audioBuf.sampleRate, fftSize: currentFftSize, overlap: getOverlapPercent() }, [audioBuf.getChannelData(0).buffer]);
   }
 });

--- a/spectrogramWorker.js
+++ b/spectrogramWorker.js
@@ -1,4 +1,5 @@
 let canvas, ctx, sampleRate = 44100;
+let aborted = false;
 
 self.onmessage = (e) => {
   const { type } = e.data;
@@ -8,7 +9,10 @@ self.onmessage = (e) => {
     ctx = canvas.getContext('2d');
   } else if (type === 'render') {
     if (!ctx) return;
+    aborted = false;
     renderSpectrogram(e.data.buffer, e.data.sampleRate || sampleRate, e.data.fftSize || 1024, e.data.overlap || 0);
+  } else if (type === 'abort') {
+    aborted = true;
   }
 };
 
@@ -22,7 +26,13 @@ function renderSpectrogram(signal, sr, fftSize, overlapPct) {
   const window = hannWindow(fftSize);
   const real = new Float32Array(fftSize);
   const imag = new Float32Array(fftSize);
+  const startTime = performance.now();
   for (let x = 0, i = 0; i + fftSize <= signal.length; i += hop, x++) {
+    if (aborted || performance.now() - startTime > 10000) {
+      aborted = false;
+      self.postMessage({ type: 'timeout' });
+      return;
+    }
     for (let j = 0; j < fftSize; j++) {
       real[j] = signal[i + j] * window[j];
       imag[j] = 0;


### PR DESCRIPTION
## Summary
- abort spectrogram rendering if it runs longer than 10 seconds
- notify users with a "Rendering Timeout" message box

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`
- `node --check spectrogramWorker.js`


------
https://chatgpt.com/codex/tasks/task_e_688ee8592018832aae694a5a627d253f