### PR TITLE
Add overlap render confirmation

### DIFF
--- a/main.js
+++ b/main.js
@@ -719,24 +719,40 @@ overlapInput.addEventListener('change', () => {
 const val = overlapInput.value.trim();
 if (val === '') {
 currentOverlap = 'auto';
-} else {
+handleOverlapChange();
+return;
+}
+
 const num = parseInt(val, 10);
 if (!isNaN(num) && num >= 1 && num <= 99) {
+const proceed = () => {
 currentOverlap = num;
+handleOverlapChange();
+};
 if (num >= 80 && !overlapWarningShown) {
 showMessageBox({
 title: 'Reminder',
-message: `Using an overlap size above 80% can significantly increase rendering time. If the .wav file is longer than 8 seconds or high-level zoom-in is enabled, large overlap sizes are not recommended.`
-});
+message: `Using an overlap size above 80% can significantly increase rendering time. If the .wav file is longer than 8 seconds or high-level zoom-in is enabled, large overlap sizes are not recommended.`,
+confirmText: 'OK',
+cancelText: 'Cancel',
+onConfirm: () => {
 overlapWarningShown = true;
+proceed();
+},
+onCancel: () => {
+overlapInput.value = '';
+currentOverlap = 'auto';
 }
+});
+return;
+}
+proceed();
 } else {
 alert('Overlap must be between 1 and 99.');
 overlapInput.value = '';
 currentOverlap = 'auto';
-}
-}
 handleOverlapChange();
+}
 });
 
 const quickPresetBtn = document.getElementById('quickPresetBtn');


### PR DESCRIPTION
## Summary
- prompt user before rendering when overlap ≥80% for the first time
- allow cancelling to avoid rendering and reset overlap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ef0982170832a9c0cca876c07ca14