### PR TITLE
Handle negative longitude for Hong Kong coordinates

### DIFF
--- a/modules/guanoReader.js
+++ b/modules/guanoReader.js
@@ -56,7 +56,19 @@ export function parseGuanoMetadata(text) {
   if (meta['Loc Position']) {
     const [lat, lon] = meta['Loc Position'].split(/\s+/);
     meta._Latitude = lat || '';
-    meta._Longitude = lon || '';
+    if (lon) {
+      let lonNum = parseFloat(lon);
+      if (!Number.isNaN(lonNum)) {
+        if (lonNum < 0 && Math.abs(lonNum) >= 113 && Math.abs(lonNum) <= 115) {
+          lonNum = Math.abs(lonNum);
+        }
+        meta._Longitude = lonNum.toString();
+      } else {
+        meta._Longitude = lon;
+      }
+    } else {
+      meta._Longitude = '';
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- Ensure GUANO metadata parser converts negative longitude values near 114°E to positive numbers so Leaflet markers show the correct position.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f40e72db8832aa47cff7092afcd40