### PR TITLE
Ensure freq-marker labels remain visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -788,6 +788,11 @@ input[type="file"]:hover {
 .freq-marker[data-title] {
   z-index: 31;
 }
+
+.freq-marker[data-title]:hover {
+  z-index: 32;
+}
+
 .freq-marker[data-title]:hover::after {
   content: attr(data-title);
   position: absolute;
@@ -800,7 +805,7 @@ input[type="file"]:hover {
   border-radius: 10px;
   white-space: nowrap;
   pointer-events: none;
-  z-index: 10;
+  z-index: 33;
   font-size: 12px;
   font-family: 'Noto Sans HK', sans-serif;
   text-transform: none;


### PR DESCRIPTION
## Summary
- raise z-index for freq-marker labels to keep tooltips above newer markers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f4efcf988832aaa26e5a87f8c833b