### PR TITLE
Preserve demo recording download during other file loads

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,7 +24,7 @@ import { initDropdown } from './modules/dropdown.js';
 import { showMessageBox } from './modules/messageBox.js';
 import { initAutoIdPanel } from './modules/autoIdPanel.js';
 import { initFreqContextMenu } from './modules/freqContextMenu.js';
-import { getCurrentIndex, getFileList, toggleFileIcon, setFileList, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
+import { getCurrentIndex, getFileList, addFilesToList, toggleFileIcon, setFileList, setCurrentIndex, clearFileList, getFileIconState, getFileNote, setFileNote, getFileMetadata, setFileMetadata, clearTrashFiles, getTrashFileCount, getCurrentFile } from './modules/fileState.js';
 
 const spectrogramHeight = 800;
 let sidebarControl;
@@ -335,10 +335,21 @@ try {
 const resp = await fetch('https://raw.githubusercontent.com/hkbatradar/SonoRadar/main/recording/demo_recording.wav');
 const blob = await resp.blob();
 const demoFile = new File([blob], 'demo_recording.wav', { type: 'audio/wav' });
-setFileList([demoFile], -1);
-toggleFileIcon(0, 'trash');
-toggleFileIcon(0, 'star');
-toggleFileIcon(0, 'question');
+const existing = getFileList();
+let demoIndex;
+if (existing.length === 0) {
+  setFileList([demoFile], -1);
+  demoIndex = 0;
+} else {
+  const currentIdx = getCurrentIndex();
+  const startIdx = existing.length;
+  addFilesToList([demoFile]);
+  setCurrentIndex(currentIdx);
+  demoIndex = startIdx;
+}
+toggleFileIcon(demoIndex, 'trash');
+toggleFileIcon(demoIndex, 'star');
+toggleFileIcon(demoIndex, 'question');
 sidebarControl.refresh(demoFile.name);
 } catch (err) {
 console.error('Failed to preload demo file', err);

--- a/modules/dragDropLoader.js
+++ b/modules/dragDropLoader.js
@@ -2,7 +2,7 @@
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
 import { getWavSampleRate, getWavDuration } from './fileLoader.js';
-import { addFilesToList, removeFilesByName, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
+import { addFilesToList, setFileMetadata, getCurrentIndex, getFileList } from './fileState.js';
 import { showMessageBox } from './messageBox.js';
 import { importKmlFile } from './mapPopup.js';
 
@@ -156,7 +156,6 @@ export function initDragDropLoader({
       updateUploadOverlay(i + 1, sortedList.length);
     }
 
-    removeFilesByName('demo_recording.wav');
     const startIdx = getFileList().length;
     if (filteredList.length > 0) {
       addFilesToList(filteredList, 0);

--- a/modules/fileLoader.js
+++ b/modules/fileLoader.js
@@ -1,7 +1,7 @@
 // modules/fileLoader.js
 
 import { extractGuanoMetadata, parseGuanoMetadata } from './guanoReader.js';
-import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, removeFilesByName, setFileMetadata } from './fileState.js';
+import { addFilesToList, getFileList, getCurrentIndex, setCurrentIndex, setFileMetadata } from './fileState.js';
 import { showMessageBox } from './messageBox.js';
 
 export async function getWavSampleRate(file) {
@@ -194,7 +194,6 @@ export function initFileLoader({
 
     const index = filteredList.findIndex(f => f.name === selectedFile.name);
 
-    removeFilesByName('demo_recording.wav');
     const startIdx = getFileList().length;
     if (filteredList.length > 0) {
       addFilesToList(filteredList, index >= 0 ? index : 0);


### PR DESCRIPTION
## Summary
- Allow demo recording to download without being overwritten when other files are loaded
- Stop automatically removing demo file when loading files via picker or drag and drop

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688f59638fd8832aaa6e0bc2f05b2d76