### PR TITLE
Hide cursor while dragging frequency markers

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -202,6 +202,7 @@ export function initAutoIdPanel({
   let startTime = null;
   let endTime = null;
   let draggingKey = null;
+  let draggingEl = null;
   let markersEnabled = true;
   let suppressResultReset = false;
 
@@ -403,7 +404,10 @@ export function initAutoIdPanel({
       if (!markersEnabled) return;
       ev.stopPropagation();
       hideHover();
+      viewer.classList.add('hide-cursor');
+      el.classList.add('hide-cursor');
       draggingKey = key;
+      draggingEl = el;
       document.addEventListener('mousemove', onMarkerDrag, { passive: true });
       document.addEventListener('mouseup', stopMarkerDrag, { once: true });
     });
@@ -543,7 +547,12 @@ export function initAutoIdPanel({
 
   function stopMarkerDrag() {
     draggingKey = null;
+    if (draggingEl) {
+      draggingEl.classList.remove('hide-cursor');
+      draggingEl = null;
+    }
     document.removeEventListener('mousemove', onMarkerDrag);
+    viewer.classList.remove('hide-cursor');
     refreshHover();
     validateMandatoryInputs();
     clearResult();

--- a/style.css
+++ b/style.css
@@ -816,6 +816,11 @@ body.markers-disabled .freq-marker {
   cursor: default !important;
 }
 
+#fixed-overlay > .freq-marker.hide-cursor,
+.freq-marker.hide-cursor {
+  cursor: none !important;
+}
+
 .marker-start { color: #e74c3c; }
 .marker-end { color: #004cff; }
 .marker-high { color: #3498db; }


### PR DESCRIPTION
## Summary
- Hide cursor while dragging frequency markers by applying hide-cursor class directly and restoring it on release
- Override marker cursor styling so move cursor CSS no longer prevents hiding

## Testing
- `node --check modules/autoIdPanel.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f70298ed4832abca8ca44c87fd744