### PR TITLE
Enable Auto ID panel activation from spectrogram results

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -75,6 +75,14 @@ export function initAutoIdPanel({
     document.dispatchEvent(new Event(isVisible ? 'autoid-close' : 'autoid-open'));
   }
 
+  function openPanel() {
+    if (panel.style.display !== 'block') {
+      panel.style.display = 'block';
+      document.body.classList.add('autoid-open');
+      document.dispatchEvent(new Event('autoid-open'));
+    }
+  }
+
   btn.addEventListener('click', togglePanel);
   closeBtn?.addEventListener('click', togglePanel);
 
@@ -426,6 +434,11 @@ export function initAutoIdPanel({
     el.className = 'pulseid-result';
     el.dataset.tab = tabIdx;
     overlay.appendChild(el);
+    el.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      openPanel();
+      switchTab(tabIdx);
+    });
     return el;
   }
 

--- a/style.css
+++ b/style.css
@@ -812,20 +812,24 @@ input[type="file"]:hover {
   font-weight: normal;
 }
 .pulseid-result {
-   position: absolute;
-   transform: translate(-50%, 0);
-   background: rgba(51, 51, 51, 0.7);
-   color: #fff;
-   padding: 3px 6px 5px 6px;
-   border-radius: 10px;
-   white-space: nowrap;
-   pointer-events: none;
-   z-index: 34;
-   font-size: 12px;
-   font-family: 'Noto Sans HK', sans-serif;
-   text-transform: none;
-   font-weight: normal;
- }
+  position: absolute;
+  transform: translate(-50%, 0);
+  background: rgba(51, 51, 51, 0.7);
+  color: #fff;
+  padding: 3px 6px 5px 6px;
+  border-radius: 10px;
+  white-space: nowrap;
+  pointer-events: auto;
+  z-index: 34;
+  font-size: 12px;
+  font-family: 'Noto Sans HK', sans-serif;
+  text-transform: none;
+  font-weight: normal;
+}
+
+.pulseid-result:hover {
+  cursor: pointer;
+}
 body.markers-disabled .freq-marker {
   pointer-events: none !important;
   cursor: default !important;


### PR DESCRIPTION
## Summary
- Make pulse ID results interactive; clicking opens the Auto ID panel and switches to the associated tag
- Display pointer cursor on pulse ID results for discoverability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906b19d95c832aa76f22e926e05327