### PR TITLE
Enable Auto ID panel activation from spectrogram results

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -75,6 +75,14 @@ export function initAutoIdPanel({
     document.dispatchEvent(new Event(isVisible ? 'autoid-close' : 'autoid-open'));
   }
 
+  function openPanel() {
+    if (panel.style.display !== 'block') {
+      panel.style.display = 'block';
+      document.body.classList.add('autoid-open');
+      document.dispatchEvent(new Event('autoid-open'));
+    }
+  }
+
   btn.addEventListener('click', togglePanel);
   closeBtn?.addEventListener('click', togglePanel);
 
@@ -426,6 +434,11 @@ export function initAutoIdPanel({
     el.className = 'pulseid-result';
     el.dataset.tab = tabIdx;
     overlay.appendChild(el);
+    el.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      openPanel();
+      switchTab(tabIdx);
+    });
     return el;
   }
 
@@ -464,7 +477,7 @@ export function initAutoIdPanel({
         rEl.style.left = `${(minX + maxX) / 2}px`;
         rEl.style.top = `${maxY + 20}px`;
         rEl.style.display = 'block';
-        rEl.style.opacity = idx === currentTab ? '1' : '0.5';
+        rEl.classList.toggle('inactive', idx !== currentTab);
       } else {
         rEl.style.display = 'none';
       }

--- a/style.css
+++ b/style.css
@@ -811,21 +811,31 @@ input[type="file"]:hover {
   text-transform: none;
   font-weight: normal;
 }
-.pulseid-result {
-   position: absolute;
-   transform: translate(-50%, 0);
-   background: rgba(51, 51, 51, 0.7);
-   color: #fff;
-   padding: 3px 6px 5px 6px;
-   border-radius: 10px;
-   white-space: nowrap;
-   pointer-events: none;
-   z-index: 34;
-   font-size: 12px;
-   font-family: 'Noto Sans HK', sans-serif;
-   text-transform: none;
-   font-weight: normal;
- }
+#fixed-overlay > .pulseid-result {
+  position: absolute;
+  transform: translate(-50%, 0);
+  background: rgba(51, 51, 51, 0.7);
+  color: #fff;
+  padding: 3px 6px 5px 6px;
+  border-radius: 10px;
+  white-space: nowrap;
+  pointer-events: auto;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+  z-index: 34;
+  font-size: 12px;
+  font-family: 'Noto Sans HK', sans-serif;
+  text-transform: none;
+  font-weight: normal;
+}
+
+#fixed-overlay > .pulseid-result.inactive {
+  opacity: 0.5;
+}
+
+#fixed-overlay > .pulseid-result.inactive:hover {
+  opacity: 1;
+}
 body.markers-disabled .freq-marker {
   pointer-events: none !important;
   cursor: default !important;


### PR DESCRIPTION
## Summary
- Make pulse ID results interactive; clicking opens the Auto ID panel and switches to the associated tag
- Display pointer cursor on pulse ID results for discoverability
- Restore inactive pulse ID result colors on hover with a smooth transition

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68906b19d95c832aa76f22e926e05327