### PR TITLE
Enable Ctrl to bypass markers

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -21,6 +21,20 @@ export function initAutoIdPanel({
   const container = document.getElementById(containerId);
   const overlay = document.getElementById(overlayId);
 
+  // Allow bypassing markers when holding the Ctrl key so that
+  // underlying path handles can be selected and dragged even when
+  // markers overlap them.
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Control') {
+      overlay.classList.add('ctrl-pressed');
+    }
+  });
+  document.addEventListener('keyup', (e) => {
+    if (e.key === 'Control') {
+      overlay.classList.remove('ctrl-pressed');
+    }
+  });
+
   const svgNS = 'http://www.w3.org/2000/svg';
   const linesSvg = document.createElementNS(svgNS, 'svg');
   linesSvg.id = 'autoid-lines';

--- a/style.css
+++ b/style.css
@@ -154,6 +154,9 @@ html, body {
   pointer-events: auto;
   cursor: move !important;
 }
+#fixed-overlay.ctrl-pressed > .freq-marker {
+  pointer-events: none;
+}
 #fixed-overlay > .path-handle {
   pointer-events: auto;
   position: absolute;


### PR DESCRIPTION
## Summary
- Allow path handles to be dragged even when overlapped by markers by holding Ctrl
- Disable marker pointer events while Ctrl is pressed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890b32e78d8832a961f23a0f5396b70