### PR TITLE
feat: allow ctrl-click to drag path handles under markers

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -218,6 +218,7 @@ export function initAutoIdPanel({
   let markersEnabled = true;
   let suppressResultReset = false;
   let markerWasDragged = false;
+  let ctrlPressed = false;
 
   function showHandlesForMarker(key) {
     activeMarkerKey = key;
@@ -533,7 +534,7 @@ export function initAutoIdPanel({
         m.el.style.left = `${x}px`;
         m.el.style.top = `${y}px`;
         m.el.style.display = 'block';
-        m.el.style.pointerEvents = idx === currentTab ? 'auto' : 'none';
+        m.el.style.pointerEvents = (idx === currentTab && !ctrlPressed) ? 'auto' : 'none';
         m.el.style.opacity = idx === currentTab ? '1' : '0.5';
         m.el.dataset.freq = m.freq;
         m.el.dataset.time = m.time;
@@ -556,6 +557,20 @@ export function initAutoIdPanel({
     });
     updateLines();
   }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Control' && !ctrlPressed) {
+      ctrlPressed = true;
+      updateMarkers();
+    }
+  });
+
+  document.addEventListener('keyup', (e) => {
+    if (e.key === 'Control' && ctrlPressed) {
+      ctrlPressed = false;
+      updateMarkers();
+    }
+  });
 
   function xyToTimeFreq(x, y) {
     const scrollLeft = viewer.scrollLeft || 0;

--- a/modules/mapPopup.js
+++ b/modules/mapPopup.js
@@ -100,6 +100,32 @@ export function initMapPopup({
   const mapDropOverlay = document.getElementById('map-drop-overlay');
   let dropCounter = 0;
 
+  let ctrlPressed = false;
+
+  function updateMarkerPointerEvents() {
+    const all = [...markers, ...textMarkers];
+    all.forEach(m => {
+      const el = m.getElement ? m.getElement() : m._icon;
+      if (el) {
+        el.style.pointerEvents = ctrlPressed ? 'none' : '';
+      }
+    });
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Control' && !ctrlPressed) {
+      ctrlPressed = true;
+      updateMarkerPointerEvents();
+    }
+  });
+
+  document.addEventListener('keyup', (e) => {
+    if (e.key === 'Control' && ctrlPressed) {
+      ctrlPressed = false;
+      updateMarkerPointerEvents();
+    }
+  });
+
   function updateCursor() {
     if (isMapDragging) {
       mapDiv.style.cursor = 'grabbing';
@@ -519,6 +545,7 @@ export function initMapPopup({
       marker.addTo(map);
       markers.push(marker);
     });
+    updateMarkerPointerEvents();
   }
 
   function clearRoute() {
@@ -741,6 +768,7 @@ export function initMapPopup({
         map.removeLayer(marker);
         textMarkers = textMarkers.filter(m => m !== marker);
       }
+      updateMarkerPointerEvents();
     };
     input.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' && !e.shiftKey) {
@@ -776,6 +804,7 @@ export function initMapPopup({
       if (textMode && !activeTextInput) {
         map.removeLayer(marker);
         textMarkers = textMarkers.filter(m => m !== marker);
+        updateMarkerPointerEvents();
       }
     });
     return marker;
@@ -789,6 +818,7 @@ export function initMapPopup({
       m.setIcon(createTextIcon(txt, textMode));
       m.setZIndexOffset(1000);
     });
+    updateMarkerPointerEvents();
   }
 
   function onMapTextClick(e) {
@@ -800,6 +830,7 @@ export function initMapPopup({
     const marker = createTextMarker(e.latlng, '');
     marker.addTo(map);
     textMarkers.push(marker);
+    updateMarkerPointerEvents();
     editTextMarker(marker);
   }
 
@@ -840,6 +871,7 @@ export function initMapPopup({
       const marker = L.marker([lat, lon], { icon, zIndexOffset: 1001 });
       marker.addTo(map);
       markers.push(marker);
+      updateMarkerPointerEvents();
     });
   }
 


### PR DESCRIPTION
## Summary
- allow holding **Ctrl** to temporarily disable map and spectrogram marker interactions
- ensure spectrogram marker updates respect Ctrl state so overlapping path handles can be dragged

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890b32e78d8832a961f23a0f5396b70