### PR TITLE
fix: preserve path handles on marker click

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -819,7 +819,7 @@ export function initAutoIdPanel({
     refreshHover();
     validateMandatoryInputs();
     clearResult();
-    if (key) {
+    if (key && markerWasDragged) {
       resetCurvesForMarker(key);
       updateLines();
     }


### PR DESCRIPTION
## Summary
- avoid resetting path handles when marker is clicked; only reset when moved

## Testing
- `npm test` (fails: ENOENT package.json)


------
https://chatgpt.com/codex/tasks/task_e_6890bd5f44fc832a9908bc0bb41c2ff5