### PR TITLE
Add hotkeys for Auto ID panel

### DIFF
--- a/modules/autoIdPanel.js
+++ b/modules/autoIdPanel.js
@@ -123,10 +123,12 @@ export function initAutoIdPanel({
   }
   harmonicDropdown.onChange = handleHarmonicChange;
   if (tabsContainer) {
+    tabsContainer.title = 'Prev tag (Ctrl + ←), Next tag (Ctrl + →)';
     for (let i = 0; i < TAB_COUNT; i++) {
       const t = document.createElement("button");
       t.textContent = `${i + 1}`;
       t.className = "tab-btn";
+      t.title = `Tag ${i + 1}`;
       if (i === 0) t.classList.add("active");
       t.addEventListener("click", () => switchTab(i));
       tabsContainer.appendChild(t);
@@ -1129,6 +1131,24 @@ export function initAutoIdPanel({
 
   pulseIdBtn?.addEventListener('click', runPulseId);
   sequenceIdBtn?.addEventListener('click', runSequenceId);
+
+  document.addEventListener('keydown', (e) => {
+    if (!document.body.classList.contains('autoid-open')) return;
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable) return;
+    if (e.key === 'Enter' && e.ctrlKey) {
+      e.preventDefault();
+      pulseIdBtn?.click();
+    } else if (e.key === 'Enter' && e.shiftKey) {
+      e.preventDefault();
+      sequenceIdBtn?.click();
+    } else if (e.ctrlKey && e.key === 'ArrowLeft') {
+      e.preventDefault();
+      if (currentTab > 0) switchTab(currentTab - 1);
+    } else if (e.ctrlKey && e.key === 'ArrowRight') {
+      e.preventDefault();
+      if (currentTab < TAB_COUNT - 1) switchTab(currentTab + 1);
+    }
+  });
 
   return {
     updateMarkers,

--- a/sonoradar.html
+++ b/sonoradar.html
@@ -253,8 +253,8 @@
         </div>
         </div>
         <div class="autoid-action-row">
-          <button id="pulseIdBtn" class="autoid-action-btn">Pulse ID</button>
-          <button id="sequenceIdBtn" class="autoid-action-btn">Sequence ID</button>
+          <button id="pulseIdBtn" class="autoid-action-btn" title="Pulse ID (Ctrl + Enter)">Pulse ID</button>
+          <button id="sequenceIdBtn" class="autoid-action-btn" title="Sequence ID (Shift + Enter)">Sequence ID</button>
         </div>
         <div class="autoid-result-row">
           <span class="autoid-result-label">Result: <span id="autoIdResult">-</span></span>


### PR DESCRIPTION
## Summary
- add keyboard shortcuts for Pulse ID, Sequence ID, and tab navigation when Auto ID panel is open
- document shortcuts with button titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890cca51abc832aa220e0dadbf13459