### PR TITLE
Hide cursor while dragging path handles

### DIFF
--- a/style.css
+++ b/style.css
@@ -862,6 +862,11 @@ body.markers-disabled .freq-marker {
   cursor: none !important;
 }
 
+#fixed-overlay > .path-handle.hide-cursor,
+.path-handle.hide-cursor {
+  cursor: none !important;
+}
+
 .marker-start { color: #e74c3c; }
 .marker-end { color: #004cff; }
 .marker-high { color: #3498db; }


### PR DESCRIPTION
## Summary
- Ensure draggable path handles hide the cursor during drag by adding CSS rules.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d63d0250832aab1aea48ab5cc6a7