### PR TITLE
Handle freqContextMenu bottom-edge overflow

### DIFF
--- a/modules/freqContextMenu.js
+++ b/modules/freqContextMenu.js
@@ -74,8 +74,13 @@ export function initFreqContextMenu({
     menu.style.display = 'block';
     menu.style.left = `${clientX}px`;
     menu.style.top = `${clientY}px`;
-    const menuRect = menu.getBoundingClientRect();
+    let menuRect = menu.getBoundingClientRect();
     const wrapperRect = wrapper.getBoundingClientRect();
+    if (menuRect.bottom > wrapperRect.bottom) {
+      const newTop = clientY - menuRect.height;
+      menu.style.top = `${Math.max(wrapperRect.top, newTop)}px`;
+      menuRect = menu.getBoundingClientRect();
+    }
     if (menuRect.right > wrapperRect.right) {
       const newLeft = clientX - menuRect.width;
       menu.style.left = `${Math.max(wrapperRect.left, newLeft)}px`;


### PR DESCRIPTION
## Summary
- keep frequency context menu within spectrogram by repositioning when opened near bottom edge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891b8b4ac2c832a935b696866537e4a